### PR TITLE
Hard code image version tag

### DIFF
--- a/incubator/faucet/faucet/Chart.yaml
+++ b/incubator/faucet/faucet/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: faucet
-version: 1.0.0
+version: 1.0.1

--- a/incubator/faucet/faucet/templates/deployment.yaml
+++ b/incubator/faucet/faucet/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       - env:
         - name: FAUCET_CONFIG_STAT_RELOAD
         - name: FAUCET_EVENT_SOCK
-        image: faucet/faucet:latest
+        image: faucet/faucet:1.9.6
         name: faucet
         ports:
         - containerPort: 6653


### PR DESCRIPTION
Along the lines of what Lincoln mentioned about security, the version tag for the docker image has been changed from latest to 1.9.6