### PR TITLE
Try to set the hostname from the Downward API

### DIFF
--- a/stable/htcondor/htcondor/Chart.yaml
+++ b/stable/htcondor/htcondor/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "8.6.12"
 description: HTCondor distributed high-throughput computing system
 name: htcondor
-version: 0.5.8
+version: 0.5.9

--- a/stable/htcondor/htcondor/templates/deployment.yaml
+++ b/stable/htcondor/htcondor/templates/deployment.yaml
@@ -89,7 +89,7 @@ spec:
         - name: _CONDOR_NUM_CPUS
           value: {{ .Values.CondorConfig.NumberCPUs | quote }}
         {{ end}}
-        - name: HOSTNAME
+        - name: _CONDOR_NETWORK_HOSTNAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName


### PR DESCRIPTION
From http://research.cs.wisc.edu/htcondor/manual/v8.6/3_5Configuration_Macros.html#23059 we can supposedly override the `gethostname()` call. Thanks @brianhlin