### PR TITLE
remove command from deployment

### DIFF
--- a/incubator/condor-ce/condor-ce/Chart.yaml
+++ b/incubator/condor-ce/condor-ce/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: 8.6.13
 description: An OSG Compute Element which provides an entry point to local batch computing resources
 name: condor-ce
-version: 0.1.8
+version: 0.1.9
 home: https://opensciencegrid.org/docs/compute-element/htcondor-ce-overview/
 

--- a/incubator/condor-ce/condor-ce/templates/deployment.yaml
+++ b/incubator/condor-ce/condor-ce/templates/deployment.yaml
@@ -24,8 +24,10 @@ spec:
         instance: {{ .Values.Instance }}
     spec:
       hostNetwork: true
+      {{ if .Values.NodeSelector }}
       nodeSelector: 
         kubernetes.io/hostname: {{ .Values.NodeSelector }}
+      {{ end }}
       containers:
       - name: condor-ce
         image: "slateci/container-condor-ce"
@@ -37,7 +39,7 @@ spec:
         - name: collector
           containerPort: 9619
           protocol: TCP
-        command: ["sh", "-c", "ln -s /cvmfs/oasis.opensciencegrid.org/osg-software/osg-wn-client/certificates /etc/grid-security/certificates"]
+        #command: ["sh", "-c", "ln -s /cvmfs/oasis.opensciencegrid.org/osg-software/osg-wn-client/certificates /etc/grid-security/certificates"]
         env:
         - name: _CONDOR_NETWORK_HOSTNAME
           valueFrom:


### PR DESCRIPTION
I believe the command I am using to create a symbolic link is overriding the entry point. Removing the command to test. 