### PR TITLE
add instance naming to pvcs for htcondor

### DIFF
--- a/stable/htcondor/htcondor/Chart.yaml
+++ b/stable/htcondor/htcondor/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "8.6.12"
 description: HTCondor distributed high-throughput computing system
 name: htcondor
-version: 0.7.0
+version: 0.7.1

--- a/stable/htcondor/htcondor/Chart.yaml
+++ b/stable/htcondor/htcondor/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "8.6.12"
 description: HTCondor distributed high-throughput computing system
 name: htcondor
-version: 0.7.1
+version: 0.7.2

--- a/stable/htcondor/htcondor/templates/deployment.yaml
+++ b/stable/htcondor/htcondor/templates/deployment.yaml
@@ -35,16 +35,16 @@ spec:
       {{ if .Values.CondorConfig.Cvmfs }}
       - name: config-osg
         persistentVolumeClaim:
-          claimName: csi-cvmfs-pvc-config-osg
+          claimName: csi-cvmfs-pvc-config-osg-{{ .Values.Instance }}
       - name: oasis
         persistentVolumeClaim:
-          claimName: csi-cvmfs-pvc-oasis
+          claimName: csi-cvmfs-pvc-oasis-{{ .Values.Instance }}
       - name: spt
         persistentVolumeClaim:
-          claimName: csi-cvmfs-pvc-spt
+          claimName: csi-cvmfs-pvc-spt-{{ .Values.Instance }}
       - name: connect
         persistentVolumeClaim:
-          claimName: csi-cvmfs-pvc-connect
+          claimName: csi-cvmfs-pvc-connect-{{ .Values.Instance }}
       {{ end }}
       - name: condor-passwordfile-volume
         secret:

--- a/stable/htcondor/htcondor/templates/pvc-config-osg.yaml
+++ b/stable/htcondor/htcondor/templates/pvc-config-osg.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: csi-cvmfs-pvc-config-osg
+  name: csi-cvmfs-pvc-config-osg-{{ .Values.Instance }}
 spec:
   accessModes:
   - ReadOnlyMany

--- a/stable/htcondor/htcondor/templates/pvc-connect.yaml
+++ b/stable/htcondor/htcondor/templates/pvc-connect.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: csi-cvmfs-pvc-connect
+  name: csi-cvmfs-pvc-connect-{{ .Values.Instance }}
 spec:
   accessModes:
   - ReadOnlyMany

--- a/stable/htcondor/htcondor/templates/pvc-oasis.yaml
+++ b/stable/htcondor/htcondor/templates/pvc-oasis.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: csi-cvmfs-pvc-oasis
+  name: csi-cvmfs-pvc-oasis-{{ .Values.Instance }}
 spec:
   accessModes:
   - ReadOnlyMany

--- a/stable/htcondor/htcondor/templates/pvc-spt.yaml
+++ b/stable/htcondor/htcondor/templates/pvc-spt.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: csi-cvmfs-pvc-spt
+  name: csi-cvmfs-pvc-spt-{{ .Values.Instance }}
 spec:
   accessModes:
   - ReadOnlyMany


### PR DESCRIPTION
Give HTCondor PVCs unique names based on the SLATE instance to prevent conflicts when installing multiple instances.