### PR TITLE
remove prometheus port from faucet service

### DIFF
--- a/stable/faucet/faucet/Chart.yaml
+++ b/stable/faucet/faucet/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.9.6"
 description: Faucet OpenFlow SDN Controller
 name: faucet
-version: 1.1.1
+version: 1.1.2

--- a/stable/faucet/faucet/templates/service.yaml
+++ b/stable/faucet/faucet/templates/service.yaml
@@ -13,9 +13,6 @@ spec:
   - name: "6653"
     port: 6653
     targetPort: 6653
-  - name: "9302"
-    port: 9302
-    targetPort: 9302
   selector:
     app: {{ template "faucet.name" . }}
     instance: {{ .Values.Instance }}


### PR DESCRIPTION
This change should allow slate instance info to get connection info for faucet.