### PR TITLE
Remove templating for the image

### DIFF
--- a/stable/xcache/xcache/Chart.yaml
+++ b/stable/xcache/xcache/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: xcache
 # Chart version
-version: 0.2.5
+version: 0.2.6
 description: XCache is a xrootd based caching service for k8s
 # Version of application packaged for installation
 appVersion: "4.9.1"

--- a/stable/xcache/xcache/templates/deployment.yaml
+++ b/stable/xcache/xcache/templates/deployment.yaml
@@ -56,8 +56,8 @@ spec:
       
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "slateci/xcache:latest"
+          imagePullPolicy: Always
           env:
           - name: XC_SPACE_HIGH_WM
             value: "{{ .Values.XCacheConfig.HighWaterMark }}"
@@ -106,7 +106,7 @@ spec:
             mountPath: "/xcache-meta"
 
         - name: x509
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "slateci/xcache:latest"
           command: ["/run_x509_updater.sh"]
           resources:
             requests:
@@ -120,7 +120,7 @@ spec:
             readOnly: true
 
         - name: reporter
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: ""slateci/xcache:latest"
           command: ["/run_cache_reporter.sh"]
           env:
           - name: XC_SITE

--- a/stable/xcache/xcache/templates/deployment.yaml
+++ b/stable/xcache/xcache/templates/deployment.yaml
@@ -120,7 +120,7 @@ spec:
             readOnly: true
 
         - name: reporter
-          image: ""slateci/xcache:latest"
+          image: "slateci/xcache:latest"
           command: ["/run_cache_reporter.sh"]
           env:
           - name: XC_SITE

--- a/stable/xcache/xcache/values.yaml
+++ b/stable/xcache/xcache/values.yaml
@@ -41,9 +41,3 @@ XCacheConfig:
   # The name of the secret that was created for your XCache certificate
   # This must be created BEFORE deploying XCache
   CertSecret: xcache-cert-secret
-
-
-image:
-  repository: slateci/xcache
-  tag: latest
-  pullPolicy: Always


### PR DESCRIPTION
We need to remove templating for the XCache image, as potentially anyone could run arbitrary images through the XCache values file. This breaks the model.