### PR TITLE
Update deployment.yaml

### DIFF
--- a/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
@@ -1,8 +1,8 @@
 # Version of Kubernetes in use
 apiVersion: v1
 # Version of application packaged for installation
-appVersion: 3.5.27
+appVersion: 4.4-2.1
 description: A Helm chart for configuration and deployment of the Open Science Grid's Frontier Squid application.
 name: osg-frontier-squid
 # Chart version
-version: 1.1.1
+version: 1.1.2

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
       # Container for the primary application, OSG Frontier Squid
       - name: osg-frontier-squid
         image: opensciencegrid/frontier-squid:fresh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         ports:
         - containerPort: 3128
           name: squid

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       containers:
       # Container for the primary application, OSG Frontier Squid
       - name: osg-frontier-squid
-        image: opensciencegrid/frontier-squid:development
+        image: opensciencegrid/frontier-squid:fresh
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3128


### PR DESCRIPTION
From OSG:
```
The frontier-squid package has a publicly announced security vulnerability that can potentially enable remote code execution from any IP address that access control allows to use the squid. All sites that have frontier-squid-4.* versions should upgrade urgently, especially those that have squids that can be used from the internet.
```