### PR TITLE
Add support for using a PVC for backing storage

### DIFF
--- a/stable/gridftp/gridftp/Chart.yaml
+++ b/stable/gridftp/gridftp/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "6.0"
 description: Globus GridFTP data management system 
 name: gridftp
-version: 0.2.12
+version: 0.2.13

--- a/stable/gridftp/gridftp/README.md
+++ b/stable/gridftp/gridftp/README.md
@@ -93,7 +93,8 @@ A typical grid-map entry might look like:
 | HostSecretName | The SLATE secret that contains the Host certificate and keys | `gridftp-host-pems` |
 | UserSecretName | The SLATE secret that contains the grid-mapfile for GridFTP, and the /etc/passwd file for the server, named 'grid-mapfile' and 'etc-passwd' respectively | `gridftp-users` |
 | GridFTPPort | The port for data & control channel access to GridFTP. These can be decoupled by advanced configuration | `2811` |
-| InternalPath | A path on the host system which should be mounted into the GridFTP container as back-end storage. | `/mnt`| 
+| InternalPath | A path on the host system which should be mounted into the GridFTP container as back-end storage. Cannot be set at the same time as PVCName. | `/mnt` |
+| PVCName | The name of a PersistentVolumeClaim which should be mounted into the GridFTP container as back-end storage. Cannot be set at the same time as InternalPath. | None | 
 | ExternalPath | The path inside the GridFTP container at which the filesystem specified by `InternalPath` should be mounted. This is the path which will be used in GridFTP URLs to manipulate data on that filesystem. | `/export` | 
 
 For more instructions on how to run GridFTP please see the [GridFTP System Administrator’s Guide](https://gridcf.org/gct-docs/6.2/gridftp/admin/index.html)
@@ -135,6 +136,8 @@ After which the file should be visible in the remote directory:
 	foo.txt
 	
 The ephemeral home directories are useful for testing, and can be used as temporary storage for small files, but for serious use it is normal to configure the `InternalPath` and `ExternalPath` in the values file to mount a non-ephemeral filesystem (typically a large, networked filesystem), and most file transfers will be to or from the base URL `gsiftp://<hostname>/<ExternalPath>/`. 
+
+Instead of using an external backing filesystem, it is also possible to use a PersistentVolumeClaim within Kubernetes as backing storage. This is more suitable for intermediate amounts of data, or for adding an authenticated interface to a PVC in which another application is storing data. 
 
 ### Error when connecting with the wrong hostname
 

--- a/stable/gridftp/gridftp/templates/deployment.yaml
+++ b/stable/gridftp/gridftp/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{ if and .Values.GridFTPConfig.InternalPath .Values.GridFTPConfig.PVCName }}
+  {{ required "InternalPath and PVCName should not both be set" .Values.Error_DoNotSet }}
+{{ end }}
 apiVersion: extensions/v1beta1
 kind: Deployment 
 metadata:
@@ -27,11 +30,17 @@ spec:
           secret:
             secretName: {{ .Values.GridFTPConfig.HostSecretName}} 
             defaultMode: 256
-        {{ if .Values.GridFTPConfig.ExternalPath }}
+        {{ if .Values.GridFTPConfig.InternalPath }}
         - name: dfs-volume
           hostPath:
           # directory location on host
-            path: {{ .Values.GridFTPConfig.ExternalPath }}
+            path: {{ .Values.GridFTPConfig.InternalPath }}
+        {{ end }}
+        {{ if .Values.GridFTPConfig.PVCName }}
+        - name: pvc-volume
+          persistentVolumeClaim:
+          # use the requested PVC:
+            claimName: {{ .Values.GridFTPConfig.PVCName }}
         {{ end }}
       containers:
         - name: gridftp
@@ -41,9 +50,15 @@ spec:
               mountPath: /opt/gridftp/users/
             - name: gridftp-host-pems
               mountPath: /tmp/gridftp-host-pems/
-            {{ if .Values.GridFTPConfig.InternalPath }}
+            {{ if and .Values.GridFTPConfig.ExternalPath .Values.GridFTPConfig.InternalPath }}
             - name: dfs-volume
-              mountPath: {{ .Values.GridFTPConfig.InternalPath }}
+              mountPath: {{ .Values.GridFTPConfig.ExternalPath }}
             {{ end }}
+            {{ if and .Values.GridFTPConfig.ExternalPath .Values.GridFTPConfig.PVCName }}
+            - name: pvc-volume
+              mountPath: {{ .Values.GridFTPConfig.ExternalPath }}
+            {{ end }}
+      {{ if .Values.GridFTPConfig.UseNodeSelector }}
       nodeSelector:
         gridftp: "true"
+      {{ end }}

--- a/stable/gridftp/gridftp/values.yaml
+++ b/stable/gridftp/gridftp/values.yaml
@@ -12,7 +12,14 @@ GridFTPConfig:
   UserSecretName: gridftp-users
   # The port GridFTP will use. 
   GridFTPPort: 2811
-  # The path for a backing filesystem to be mounted from the host system. 
-  InternalPath: /mnt
   # The path at which the storage should be mounted. 
   ExternalPath: /export
+  # The path for a backing filesystem to be mounted from the host system. 
+  InternalPath: /mnt
+  # The name of a PersistentVolumeClaim which should be mounted as backing storage.
+  PVCName: 
+  # If set, use a nodeSelector (`gridftp=true`) to run only on a matching nodes. 
+  # This is useful when only certain nodes on the cluster mount the appropriate 
+  # backing filesystem. It may be desirable to turn this off when using a PVC as
+  # backing storage, since this tends not to tie to a specific node. 
+  UseNodeSelector: true


### PR DESCRIPTION
This both adds use of a PVC as an alternative to a HostPath volume, and also un-mixes-up the ways the paths are used in the deployment. 