### PR TITLE
Update supervisord.conf to fix illegal seek

### DIFF
--- a/incubator/login-node/images/container-login-node/container-files/etc/supervisord.conf
+++ b/incubator/login-node/images/container-login-node/container-files/etc/supervisord.conf
@@ -1,3 +1,4 @@
 [supervisord]
 nodaemon=true
 logfile=/dev/stdout
+logfile_maxbytes=0


### PR DESCRIPTION
This fixes the following bug:
```
Traceback (most recent call last):
  File "/usr/bin/supervisord", line 9, in <module>
    load_entry_point('supervisor==3.1.4', 'console_scripts', 'supervisord')()
  File "/usr/lib/python2.7/site-packages/supervisor/supervisord.py", line 366, in main
    go(options)
  File "/usr/lib/python2.7/site-packages/supervisor/supervisord.py", line 376, in go
    d.main()
  File "/usr/lib/python2.7/site-packages/supervisor/supervisord.py", line 77, in main
    info_messages)
  File "/usr/lib/python2.7/site-packages/supervisor/options.py", line 1332, in make_logger
    self.logger.critical(msg)
  File "/usr/lib/python2.7/site-packages/supervisor/loggers.py", line 287, in critical
    self.log(LevelsByName.CRIT, msg, **kw)
  File "/usr/lib/python2.7/site-packages/supervisor/loggers.py", line 293, in log
    handler.emit(record)
  File "/usr/lib/python2.7/site-packages/supervisor/loggers.py", line 186, in emit
    self.doRollover()
  File "/usr/lib/python2.7/site-packages/supervisor/loggers.py", line 211, in doRollover
    if not (self.stream.tell() >= self.maxBytes):
IOError: [Errno 29] Illegal seek
```