### PR TITLE
Drop unnecessary osg-configure values

### DIFF
--- a/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "8.6.12"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 0.2.16
+version: 0.2.17

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -32,7 +32,6 @@ data:
     max_jobs = {{ .Values.Cluster.MaxJobs }}
 
     [Misc Services]
-    glexec_location = None
     edit_lcmaps_db = True
     authorization_method = vomsmap
 
@@ -46,27 +45,10 @@ data:
 
     [Subcluster {{ .Values.Subcluster.Name }}]
     name = {{ .Values.Subcluster.Name }}
-    node_count = {{ .Values.Subcluster.NodeCount }}
     ram_mb = {{ .Values.Subcluster.Memory }}
-    cpu_model = Intel
-    cpu_vendor = Intel
-    cpu_speed_mhz =  2500
-    cpus_per_node = {{ .Values.Subcluster.CpusPerNode }}
     cores_per_node = {{ .Values.Subcluster.CoresPerNode }}
-    inbound_network = FALSE
-    outbound_network = TRUE
-    cpu_platform = x86_64
     max_wall_time = {{ .Values.Subcluster.MaxWallTime }}
     allowed_vos = {{ .Values.Subcluster.AllowedVOs }}
-
-
-    [SE_dummy]
-    enabled = False
-    name = dummy
-    srm_endpoint =  srm://srm.example.com:8443/srm/v2/server
-    provider_implementation  = bestman
-    implementation  = bestman
-
 
     [Squid]
     enabled = {{ .Values.Squid.Enabled }} 

--- a/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -25,7 +25,6 @@ Storage:
 
 Subcluster:
   Name: UCHICAGO-SLATE
-  NodeCount: 1
   Memory: 1024
   CoresPerNode: 4
   MaxWallTime: 1440

--- a/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -27,7 +27,6 @@ Subcluster:
   Name: UCHICAGO-SLATE
   NodeCount: 1
   Memory: 1024
-  CpusPerNode: 4
   CoresPerNode: 4
   MaxWallTime: 1440
   AllowedVOs: osg, cms, atlas, glow


### PR DESCRIPTION
- glexec is dropped
- most of the subcluster values aren't reported anymore
- don't need a dummy SE