### PR TITLE
[osg-hosted-ce] Support additional slurm configurations

### DIFF
--- a/incubator/condor-login/condor-login/Chart.yaml
+++ b/incubator/condor-login/condor-login/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: login is
 name: condor-login
-version: 3.3.13
+version: 3.3.14
 appVersion: 1.0.0
 maintainers:
   - name: lincoln bryant

--- a/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "8.6.12"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 0.2.19
+version: 0.3.0

--- a/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "8.6.12"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 0.2.18
+version: 0.2.19

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -87,15 +87,3 @@ data:
 {{ .Values.CustomizationScript | indent 4 }}
 {{ end }}
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: osg-hosted-ce-{{ .Values.Instance }}-site-variables
-  labels:
-    app: osg-hosted-ce
-    chart: {{ template "osg-hosted-ce.chart" . }}
-    instance: {{ .Values.Instance }}
-    release: {{ .Release.Name }}
-data:
-  slurm_binpath={{ .Values.SiteConfig.SlurmBinPath }}
----

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -87,3 +87,15 @@ data:
 {{ .Values.CustomizationScript | indent 4 }}
 {{ end }}
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: osg-hosted-ce-{{ .Values.Instance }}-site-variables
+  labels:
+    app: osg-hosted-ce
+    chart: {{ template "osg-hosted-ce.chart" . }}
+    instance: {{ .Values.Instance }}
+    release: {{ .Release.Name }}
+data:
+  slurm_binpath={{ .Values.SiteConfig.SlurmBinPath }}
+---

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -83,4 +83,6 @@ spec:
         {{ if .Values.CustomizationScript }}
         - name: LOCAL_ATTRIBUTES_FILE
           value: /tmp/{{ .Values.Cluster.Batch }}_local_submit_attributes.sh
+        - name: slurm_binpath
+          value: {{ .Values.SiteConfig.SlurmBinPath }}
         {{ end }}

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -83,6 +83,6 @@ spec:
         {{ if .Values.CustomizationScript }}
         - name: LOCAL_ATTRIBUTES_FILE
           value: /tmp/{{ .Values.Cluster.Batch }}_local_submit_attributes.sh
+        {{ end }}
         - name: slurm_binpath
           value: {{ .Values.SiteConfig.SlurmBinPath }}
-        {{ end }}

--- a/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -34,6 +34,11 @@ Squid:
   Enabled: True
   Location: squid.grid.uchicago.edu
 
+# Special site specific modifications
+
+SiteConfig:
+  SlurmBinPath: ''
+
 # If you wish to allow yourself to submit to this CE with your personal grid
 # proxy, you can put that in below. This will get directly mapped into
 # /etc/grid-security/grid-mapfile


### PR DESCRIPTION
- Add path configuration to values

- Plumb path to the container as an environment variable

- Push that to the correct scripts on the remote side (See https://github.com/slateci/container-osg-hostedce/pull/1)