### PR TITLE
Add bosco override support to osg-hosted-ce

### DIFF
--- a/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "8.6.12"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 0.2.19
+version: 0.3.0

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       volumes:
       - name: osg-hosted-ce-{{ .Values.Instance }}-configuration
         configMap:
-          name: osg-hosted-ce-{{ .Values.Instance}}-configuration
+          name: osg-hosted-ce-{{ .Values.Instance }}-configuration
       {{ if .Values.CustomizationScript }}
       - name: osg-hosted-ce-{{ .Values.Instance }}-cluster-configuration
         configMap:

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -44,6 +44,15 @@ spec:
           - key: bosco.key
             path: bosco.key
             mode: 256
+      {{ if .Values.BoscoOverrides.RepoNeedsPrivKey }}
+      - name: osg-hosted-ce-{{ .Values.Instance }}-gitkey
+        secret:
+          secretName: {{ .Values.BoscoOverrides.GitKeySecret }}
+          items:
+          - key: git.key
+            path: git.key
+            mode: 256 
+      {{ end }}
       hostNetwork: true
       containers:
       - name: osg-hosted-ce
@@ -55,7 +64,7 @@ spec:
         - name: bosco-ssh-private-key-volume
           mountPath: /etc/osg/bosco.key
           subPath: bosco.key
-        {{ if .Values.BoscoOverrides.RepoNeedsPrivKey}}
+        {{ if .Values.BoscoOverrides.RepoNeedsPrivKey }}
         - name: osg-hosted-ce-{{ .Values.Instance }}-gitkey
           mountPath: /etc/osg/git.key
           subPath: git.key

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -49,12 +49,17 @@ spec:
       - name: osg-hosted-ce
         image: slateci/container-osg-hostedce:latest
         volumeMounts:
-        - name: osg-hosted-ce-{{ .Values.Instance}}-configuration
+        - name: osg-hosted-ce-{{ .Values.Instance }}-configuration
           mountPath: /tmp/99-local.ini
           subPath: 99-local.ini
         - name: bosco-ssh-private-key-volume
           mountPath: /etc/osg/bosco.key
           subPath: bosco.key
+        {{ if .Values.BoscoOverrides.RepoNeedsPrivKey}}
+        - name: osg-hosted-ce-{{ .Values.Instance }}-gitkey
+          mountPath: /etc/osg/git.key
+          subPath: git.key
+        {{ end }}
         {{ if .Values.CustomizationScript }}
         - name: osg-hosted-ce-{{ .Values.Instance }}-cluster-configuration
           mountPath: /tmp/{{ .Values.Cluster.Batch }}_local_submit_attributes.sh
@@ -83,4 +88,10 @@ spec:
         {{ if .Values.CustomizationScript }}
         - name: LOCAL_ATTRIBUTES_FILE
           value: /tmp/{{ .Values.Cluster.Batch }}_local_submit_attributes.sh
+        {{ end }}
+        {{ if .Values.BoscoOverrides.Enabled }}
+        - name: BOSCO_GIT_ENDPOINT
+          value: {{ .Values.BoscoOverrides.GitEndpoint }}
+        - name: BOSCO_DIRECTORY
+          value: {{ .Values.BoscoOverrides.Subdirectory }}
         {{ end }}

--- a/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -39,7 +39,8 @@ BoscoOverrides:
   Enabled: true
   GitEndpoint: git@gitlab.mwt2.org:osg/hosted-ce-config.git
   Subdirectory: OSG_US_NEWJERSEY_ELSA
-  GitSecretKey: mwtGitLabSecret
+  RepoNeedsPrivKey: true
+  GitKeySecret: mwtGitLabSecret
 
 # If you wish to allow yourself to submit to this CE with your personal grid
 # proxy, you can put that in below. This will get directly mapped into

--- a/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -34,6 +34,13 @@ Squid:
   Enabled: True
   Location: squid.grid.uchicago.edu
 
+# Options to allow override of the bosco directory from arbitrary git repos
+BoscoOverrides:
+  Enabled: true
+  GitEndpoint: git@gitlab.mwt2.org:osg/hosted-ce-config.git
+  Subdirectory: OSG_US_NEWJERSEY_ELSA
+  GitSecretKey: mwtGitLabSecret
+
 # If you wish to allow yourself to submit to this CE with your personal grid
 # proxy, you can put that in below. This will get directly mapped into
 # /etc/grid-security/grid-mapfile


### PR DESCRIPTION
-Add a git endpoint for a repo that contains bosco override files

-Support subpaths for different sites within that repo

-Suppport an SSH private key mounted as a SLATE secret for gitlab