### PR TITLE
Add developer mode (SOFTWARE-3906)

### DIFF
--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -10,7 +10,11 @@ metadata:
 data:
   99-local.ini: |
     [Site Information]
-    group = {{ .Values.Site.Group }}
+    {{ if .Values.Developer.Enabled }}
+    group = OSG-ITB
+    {{ else }}
+    group = OSG
+    {{ end }}
     host_name = localhost
     resource = {{ .Values.Site.Resource }}
     resource_group = {{ .Values.Site.ResourceGroup }}

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -134,6 +134,8 @@ spec:
           value: {{ .Values.Site.ContactEmail }}
         - name: CE_USERS
           value: {{ .Values.Cluster.Users }}
+        - name: DEVELOPER
+          value: {{ .Values.Developer.Enabled }}
         {{ if .Values.CustomizationScript }}
         - name: LOCAL_ATTRIBUTES_FILE
           value: /tmp/{{ .Values.Cluster.Batch }}_local_submit_attributes.sh

--- a/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -72,6 +72,9 @@ HTTPLogger:
 #  #!/bin/sh 
 #  ... 
 
-# FOR DEVELOPMENT PURPOSES ONLY
+# FOR DEVELOPMENT PURPOSES ONLY!
+# Setting 'Enabled: true' below does the following:
+# - Configures the CE as an ITB host
+# - Generates a test CA and self-signed host cert/key pair
 Developer:
   Enabled: false

--- a/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -71,3 +71,7 @@ HTTPLogger:
 #CustomizationScript: |+
 #  #!/bin/sh 
 #  ... 
+
+# FOR DEVELOPMENT PURPOSES ONLY
+Developer:
+  Enabled: false


### PR DESCRIPTION
The OSG container is being updated to support a developer mode: https://github.com/opensciencegrid/docker-hosted-ce/pull/12. I added the developer option to the values file for now but I'd be ok taking it out or removing it when we get closer to prod-ready.