### PR TITLE
Consolidate resource name in the Hosted CE helm chart (SOFTWARE-3729)

### DIFF
--- a/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "8.6.12"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 0.4.14
+version: 0.4.15

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -47,8 +47,8 @@ data:
     data_dir = None
     worker_node_temp = {{ .Values.Storage.WorkerNodeTemp }}
 
-    [Subcluster {{ .Values.Subcluster.Name }}]
-    name = {{ .Values.Subcluster.Name }}
+    [Subcluster {{ .Values.Site.Resource }}]
+    name = {{ .Values.Site.Resource }}
     ram_mb = {{ .Values.Subcluster.Memory }}
     cores_per_node = {{ .Values.Subcluster.CoresPerNode }}
     max_wall_time = {{ .Values.Subcluster.MaxWallTime }}

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -149,7 +149,7 @@ spec:
         - name: BOSCO_GIT_ENDPOINT
           value: {{ .Values.BoscoOverrides.GitEndpoint }}
         - name: BOSCO_DIRECTORY
-          value: {{ .Values.BoscoOverrides.Subdirectory }}
+          value: {{ .Values.Site.Resource }}
         {{ end }}
         lifecycle:
           preStop:

--- a/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -1,5 +1,6 @@
 Instance: ""
 
+# Site information that should match the CE Topology registration
 Site:
   Group: OSG
   Resource: UCHICAGO-SLATE
@@ -44,6 +45,8 @@ Networking:
   RequestIP: null
 
 # Options to allow override of the bosco directory from arbitrary git repos
+# Bosco override dirs are expected in the following location in the git repo:
+#   <RESOURCE NAME>/bosco_override/
 BoscoOverrides:
   Enabled: true
   GitEndpoint: git@gitlab.mwt2.org:osg/hosted-ce-config.git

--- a/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -24,7 +24,6 @@ Storage:
   WorkerNodeTemp: /tmp
 
 Subcluster:
-  Name: UCHICAGO-SLATE
   Memory: 1024
   CoresPerNode: 4
   MaxWallTime: 1440
@@ -48,7 +47,6 @@ Networking:
 BoscoOverrides:
   Enabled: true
   GitEndpoint: git@gitlab.mwt2.org:osg/hosted-ce-config.git
-  Subdirectory: OSG_US_NEWJERSEY_ELSA
   RepoNeedsPrivKey: true
   GitKeySecret: mwtGitLabSecret
 


### PR DESCRIPTION
@matyasselmeci does this look ok to you? I think we agreed that for the Hosted CE case, setting the subcluster name to the resource name was ok.

https://opensciencegrid.atlassian.net/browse/SOFTWARE-3904