### PR TITLE
Add ability to specify HTCondor-CE configuration (SOFTWARE-3921)

### DIFF
--- a/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "8.6.12"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 0.5.0
+version: 0.6.0

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -60,6 +60,19 @@ data:
     policy = DEFAULT
     cache_size = DEFAULT
     memory_size = DEFAULT
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: osg-hosted-ce-{{ .Values.Instance }}-htcondor-ce-configuration
+  labels:
+    app: osg-hosted-ce
+    chart: {{ template "osg-hosted-ce.chart" . }}
+    instance: {{ .Values.Instance }}
+    release: {{ .Release.Name }}
+data:
+  99-instance.conf: |+
+{{ .Values.HTCondorCeConfig | indent 4 }}
 {{ if .Values.VomsmapOverride }}
 ---
 apiVersion: v1

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -35,6 +35,11 @@ spec:
         configMap:
           name: osg-hosted-ce-{{ .Values.Instance }}-cluster-configuration
       {{ end }}
+      {{ if .Values.VomsmapOverride }}
+      - name: osg-hosted-ce-{{ .Values.Instance }}-voms-mapfile
+        configMap:
+          name: osg-hosted-ce-{{ .Values.Instance }}-voms-mapfile
+      {{ end }}
       {{ if .Values.GridmapOverride }}
       - name: osg-hosted-ce-{{ .Values.Instance }}-grid-mapfile
         configMap:

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
       - name: osg-hosted-ce-{{ .Values.Instance }}-configuration
         configMap:
           name: osg-hosted-ce-{{ .Values.Instance }}-configuration
+      - name: osg-hosted-ce-{{ .Values.Instance }}-htcondor-ce-configuration
+        configMap:
+          name: osg-hosted-ce-{{ .Values.Instance }}-htcondor-ce-configuration
       {{ if .Values.CustomizationScript }}
       - name: osg-hosted-ce-{{ .Values.Instance }}-cluster-configuration
         configMap:
@@ -98,6 +101,9 @@ spec:
         - name: bosco-ssh-private-key-volume
           mountPath: /etc/osg/bosco.key
           subPath: bosco.key
+        - name: osg-hosted-ce-{{ .Values.Instance }}-htcondor-ce-configuration
+          mountPath: /etc/condor-ce/config.d/99-instance.conf
+          subPath: 99-instance.conf
         {{ if .Values.HTTPLogger.Enabled }}
         - name: log-volume
           mountPath: /var/log/condor-ce

--- a/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -44,6 +44,18 @@ Networking:
   # back the same IP address that was used previously. 
   RequestIP: null
 
+########### REQUIRED ###########
+# Specify additional HTCondor-CE configuration. JOB_ROUTER_ENTRIES is required!
+# HTCondorCeConfig: |+
+#   JOB_ROUTER_ENTRIES =@jre
+#   [
+#     GridResource = "batch <REMOTE USER>@<REMOTE HOST> <REMOTE BATCH>"
+#     Requirements = 'Owner == "<REMOTE USER>"'
+#   ]
+#   [
+#   ...
+#   @jre
+
 # Options to allow override of the bosco directory from arbitrary git repos
 # Bosco override dirs are expected in the following location in the git repo:
 #   <RESOURCE NAME>/bosco_override/


### PR DESCRIPTION
And missed volume specification for the `voms-mapfile`. There really is a lot of repetition in Kubernetes config...