### PR TITLE
Remove the release from the nginx service, as Kubernetes 1.16 does not seem to like it

### DIFF
--- a/stable/nginx/nginx/Chart.yaml
+++ b/stable/nginx/nginx/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: "v1"
 name: "nginx"
-version: 1.1.2
+version: 1.1.3
 appVersion: 1.15.9
 description: "A simple nginx deployment which serves a static page"

--- a/stable/nginx/nginx/templates/service.yaml
+++ b/stable/nginx/nginx/templates/service.yaml
@@ -17,7 +17,6 @@ spec:
   selector:
     app: {{ template "nginx.name" . }}
     instance: {{ .Values.Instance }}
-release: {{ .Release.Name }}
 ---
 {{ if .Values.Ingress.Enabled }}
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
I'm not sure why we didn't run into this before, but without this change I get an error:
`Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Service): unknown field "release" in io.k8s.api.core.v1.Service`
Removing the apparently offending property allows the chart to install cleanly. 