### PR TITLE
Add HTTPLogger and configurable passwords

### DIFF
--- a/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "8.6.12"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 0.4.10
+version: 0.5.0

--- a/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "8.6.12"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 0.4.9
+version: 0.4.10

--- a/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "8.6.12"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 0.4.8
+version: 0.4.9

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -91,12 +91,47 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: osg-hosted-ce-{{ .Values.Instance }}-logpasswd
+  name: osg-hosted-ce-{{ .Values.Instance }}-logger-startup
   labels:
     app: osg-hosted-ce
     chart: {{ template "osg-hosted-ce.chart" . }}
     instance: {{ .Values.Instance }}
     release: {{ .Release.Name }}
 data:
-  htpasswd: condor:$apr1$DCKqQH3N$28tCq.SR5dinWT9fwLurq0
+  start-nginx.sh: |+
+    #!/bin/bash -e
+    
+    apt-get update
+    apt-get install openssl -y
+  
+    if [ -z $HTPASSWD ]; then
+      PASS=$(tr -dc 'a-f0-9' < /dev/urandom | head -c16)
+      echo "Your randomly generated logger credentials are"
+      echo "**********************************************"
+      echo "logger:$PASS"
+      echo "**********************************************"
+      HTPASSWD="$(openssl passwd -apr1 $(echo -n $PASS))"
+    fi
+  
+    # maybe validate this
+    mkdir -p /etc/nginx/auth
+    echo "logger:$HTPASSWD" > /etc/nginx/auth/htpasswd
+
+    echo 'server {
+      listen       8080;
+      server_name  localhost;
+      location / {
+        default_type text/plain;
+        auth_basic "Restricted";
+        auth_basic_user_file /etc/nginx/auth/htpasswd;  
+        root   /usr/share/nginx/html;
+        autoindex  on;
+      }
+      error_page   500 502 503 504  /50x.html;
+      location = /50x.html {
+        root   /usr/share/nginx/html;
+      }
+    }' > /etc/nginx/conf.d/default.conf
+    exec nginx -g 'daemon off;'
+
 {{ end }}

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -37,13 +37,13 @@ spec:
         configMap:
           name: osg-hosted-ce-{{ .Values.Instance }}-grid-mapfile
       {{ end }}
-      #- name: bosco-ssh-private-key-volume
-      #  secret: 
-      #    secretName: {{ .Values.Cluster.PrivateKeySecret }}
-      #    items:
-      #    - key: bosco.key
-      #      path: bosco.key
-      #      mode: 256
+      - name: bosco-ssh-private-key-volume
+        secret: 
+          secretName: {{ .Values.Cluster.PrivateKeySecret }}
+          items:
+          - key: bosco.key
+            path: bosco.key
+            mode: 256
       {{ if .Values.BoscoOverrides.Enabled }}
       {{ if .Values.BoscoOverrides.RepoNeedsPrivKey }}
       - name: osg-hosted-ce-{{ .Values.Instance }}-gitkey
@@ -103,9 +103,9 @@ spec:
         - name: osg-hosted-ce-{{ .Values.Instance }}-configuration
           mountPath: /tmp/99-local.ini
           subPath: 99-local.ini
-        #- name: bosco-ssh-private-key-volume
-        #  mountPath: /etc/osg/bosco.key
-        #  subPath: bosco.key
+        - name: bosco-ssh-private-key-volume
+          mountPath: /etc/osg/bosco.key
+          subPath: bosco.key
         {{ if .Values.HTTPLogger.Enabled }}
         - name: log-volume
           mountPath: /var/log/condor-ce

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -62,6 +62,15 @@ spec:
         configMap:
           name: osg-hosted-ce-{{ .Values.Instance }}-logpasswd
       {{ end }}
+      {{ if .Values.HTTPLogger.Enabled }}
+      initContainers:
+      - name: logging-sidecar-init
+        image: opensciencegrid/hosted-ce:fresh
+        command: ['/bin/chown','condor:condor','/var/log/condor-ce']
+        volumeMounts:
+        - name: log-volume
+          mountPath: /var/log/condor-ce
+      {{ end }}
       containers:
       {{ if .Values.HTTPLogger.Enabled }}
       - name: logging-sidecar
@@ -106,15 +115,6 @@ spec:
         - name: osg-hosted-ce-{{ .Values.Instance }}-grid-mapfile
           mountPath: /etc/grid-security/grid-mapfile
           subPath: grid-mapfile
-        {{ end }}
-        {{ if .Values.HTTPLogger.Enabled }}
-        initContainers:
-        - name: logging-sidecar-init
-          image: opensciencegrid/hosted-ce:fresh
-          command: ['/bin/chown','condor:condor','/var/log/condor-ce']
-          volumeMounts:
-          - name: log-volume
-            mountPath: /var/log/condor-ce
         {{ end }}
         ports:
         - name: htcondor-ce

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -107,6 +107,15 @@ spec:
           mountPath: /etc/grid-security/grid-mapfile
           subPath: grid-mapfile
         {{ end }}
+        {{ if .Values.HTTPLogger.Enabled }}
+        initContainers:
+        - name: logging-sidecar-init
+          image: opensciencegrid/hosted-ce:fresh
+          command: ['/bin/chown','condor:condor','/var/log/condor-ce']
+          volumeMounts:
+          - name: log-volume
+            mountPath: /var/log/condor-ce
+        {{ end }}
         ports:
         - name: htcondor-ce
           containerPort: 9619

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -37,13 +37,13 @@ spec:
         configMap:
           name: osg-hosted-ce-{{ .Values.Instance }}-grid-mapfile
       {{ end }}
-      - name: bosco-ssh-private-key-volume
-        secret: 
-          secretName: {{ .Values.Cluster.PrivateKeySecret }}
-          items:
-          - key: bosco.key
-            path: bosco.key
-            mode: 256
+      #- name: bosco-ssh-private-key-volume
+      #  secret: 
+      #    secretName: {{ .Values.Cluster.PrivateKeySecret }}
+      #    items:
+      #    - key: bosco.key
+      #      path: bosco.key
+      #      mode: 256
       {{ if .Values.BoscoOverrides.Enabled }}
       {{ if .Values.BoscoOverrides.RepoNeedsPrivKey }}
       - name: osg-hosted-ce-{{ .Values.Instance }}-gitkey
@@ -58,9 +58,9 @@ spec:
       {{ if .Values.HTTPLogger.Enabled }}
       - name: log-volume
         emptyDir: {} 
-      - name: osg-hosted-ce-{{ .Values.Instance }}-logpasswd
+      - name: osg-hosted-ce-{{ .Values.Instance }}-logger-startup
         configMap:
-          name: osg-hosted-ce-{{ .Values.Instance }}-logpasswd
+          name: osg-hosted-ce-{{ .Values.Instance }}-logger-startup
       {{ end }}
       {{ if .Values.HTTPLogger.Enabled }}
       initContainers:
@@ -77,16 +77,25 @@ spec:
         volumeMounts:
         - name: log-volume
           mountPath: /usr/share/nginx/html
-        - name: osg-hosted-ce-{{ .Values.Instance }}-logpasswd
-          mountPath: /etc/nginx/auth
+        - name: osg-hosted-ce-{{ .Values.Instance }}-logger-startup
+          mountPath: /usr/local/bin/start-nginx.sh
+          subPath: start-nginx.sh
         ports: 
         - name: logs
           containerPort: 8080
           protocol: TCP
         image: "nginx:1.15.9"
         command: ["/bin/bash"]
-        args: ["-c", "sed -i -e 's|\\(listen[^0-9]*\\)80|\\1 8080|' -e 's|index  index.html index.htm|autoindex  on|'  -e '/location \\/ {/ a\\        auth_basic           \"Restricted\";\\\n\\        auth_basic_user_file /etc/nginx/auth/htpasswd;' /etc/nginx/conf.d/default.conf && exec nginx -g 'daemon off;'"]
+        args: ["/usr/local/bin/start-nginx.sh"]
         imagePullPolicy: IfNotPresent
+        {{ if .Values.HTTPLogger.Secret }}
+        env:
+          - name: HTPASSWD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.HTTPLogger.Secret }}
+                key: HTPASSWD
+        {{ end }}
       {{ end }}
       - name: osg-hosted-ce
         image: opensciencegrid/hosted-ce:fresh
@@ -94,9 +103,9 @@ spec:
         - name: osg-hosted-ce-{{ .Values.Instance }}-configuration
           mountPath: /tmp/99-local.ini
           subPath: 99-local.ini
-        - name: bosco-ssh-private-key-volume
-          mountPath: /etc/osg/bosco.key
-          subPath: bosco.key
+        #- name: bosco-ssh-private-key-volume
+        #  mountPath: /etc/osg/bosco.key
+        #  subPath: bosco.key
         {{ if .Values.HTTPLogger.Enabled }}
         - name: log-volume
           mountPath: /var/log/condor-ce

--- a/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -49,7 +49,7 @@ BoscoOverrides:
   Enabled: true
   GitEndpoint: git@gitlab.mwt2.org:osg/hosted-ce-config.git
   Subdirectory: OSG_US_NEWJERSEY_ELSA
-  RepoNeedsPrivKey: false
+  RepoNeedsPrivKey: true
   GitKeySecret: mwtGitLabSecret
 
 # Enable a logging sidecar

--- a/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -49,12 +49,15 @@ BoscoOverrides:
   Enabled: true
   GitEndpoint: git@gitlab.mwt2.org:osg/hosted-ce-config.git
   Subdirectory: OSG_US_NEWJERSEY_ELSA
-  RepoNeedsPrivKey: true
+  RepoNeedsPrivKey: false
   GitKeySecret: mwtGitLabSecret
 
 # Enable a logging sidecar
 HTTPLogger:
-  Enabled: false
+  Enabled: true
+  # If you want to insert a password instead of using a randomly generated one,
+  # point Secret to a K8S/SLATE secret below.
+  Secret: lincoln-test-secret
 
 # If you wish to allow yourself to submit to this CE with your personal grid
 # proxy, you can put that in below. This will get directly mapped into

--- a/stable/htcondor/htcondor/Chart.yaml
+++ b/stable/htcondor/htcondor/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "8.6.13"
 description: HTCondor distributed high-throughput computing system
 name: htcondor
-version: 0.8.5
+version: 0.9.0

--- a/stable/htcondor/htcondor/Chart.yaml
+++ b/stable/htcondor/htcondor/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "8.6.13"
 description: HTCondor distributed high-throughput computing system
 name: htcondor
-version: 0.9.0
+version: 0.9.1

--- a/stable/htcondor/htcondor/templates/configmap.yaml
+++ b/stable/htcondor/htcondor/templates/configmap.yaml
@@ -10,3 +10,31 @@ metadata:
 data:
   condor_config.local: |-
 {{ .Values.CondorConfigFile | indent 4 }}
+{{ if .Values.HTTPLogger.Enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: htcondor-{{ .Values.Instance }}-logger-startup
+  labels:
+    app: htcondor
+    chart: {{ template "htcondor.chart" . }}
+    instance: {{ .Values.Instance }}
+    release: {{ .Release.Name }}
+data:
+      #!/bin/bash -e
+
+      if [ -z $HTPASSWD ]; then
+        PASS=$(tr -dc 'a-f0-9' < /dev/urandom | head -c16) 
+        echo "Your randomly generated logger credentials are"
+        echo "**********************************************"
+        echo "logger:$PASS"
+        echo "**********************************************"
+        HTPASSWD=$(echo $PASS | md5sum | awk '{print "logger:"$1}')
+      fi
+
+      # maybe validate this
+      echo $HTPASSWD > /etc/nginx/auth/htpasswd
+
+      sed -i -e 's|\\(listen[^0-9]*\\)80|\\1 8080|' -e 's|index  index.html index.htm|autoindex  on|'  -e '/location \\/ {/ a\\        default_type         text/plain;\\\n\\        auth_basic           \"Restricted\";\\\n\\        auth_basic_user_file /etc/nginx/auth/htpasswd;' /etc/nginx/conf.d/default.conf && exec nginx -g 'daemon off;'
+{{ end }}

--- a/stable/htcondor/htcondor/templates/configmap.yaml
+++ b/stable/htcondor/htcondor/templates/configmap.yaml
@@ -10,31 +10,53 @@ metadata:
 data:
   condor_config.local: |-
 {{ .Values.CondorConfigFile | indent 4 }}
+{{ end }}
 {{ if .Values.HTTPLogger.Enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: htcondor-{{ .Values.Instance }}-logger-startup
+  name: osg-hosted-ce-{{ .Values.Instance }}-logger-startup
   labels:
-    app: htcondor
-    chart: {{ template "htcondor.chart" . }}
+    app: osg-hosted-ce
+    chart: {{ template "osg-hosted-ce.chart" . }}
     instance: {{ .Values.Instance }}
     release: {{ .Release.Name }}
 data:
-      #!/bin/bash -e
+  start-nginx.sh: |+
+    #!/bin/bash -e
 
-      if [ -z $HTPASSWD ]; then
-        PASS=$(tr -dc 'a-f0-9' < /dev/urandom | head -c16) 
-        echo "Your randomly generated logger credentials are"
-        echo "**********************************************"
-        echo "logger:$PASS"
-        echo "**********************************************"
-        HTPASSWD=$(echo $PASS | md5sum | awk '{print "logger:"$1}')
-      fi
+    # not ideal
+    apt-get update
+    apt-get install openssl -y
 
-      # maybe validate this
-      echo $HTPASSWD > /etc/nginx/auth/htpasswd
+    if [ -z $HTPASSWD ]; then
+      PASS=$(tr -dc 'a-f0-9' < /dev/urandom | head -c16)
+      echo "Your randomly generated logger credentials are"
+      echo "**********************************************"
+      echo "logger:$PASS"
+      echo "**********************************************"
+      HTPASSWD="$(openssl passwd -apr1 $(echo -n $PASS))"
+    fi
 
-      sed -i -e 's|\\(listen[^0-9]*\\)80|\\1 8080|' -e 's|index  index.html index.htm|autoindex  on|'  -e '/location \\/ {/ a\\        default_type         text/plain;\\\n\\        auth_basic           \"Restricted\";\\\n\\        auth_basic_user_file /etc/nginx/auth/htpasswd;' /etc/nginx/conf.d/default.conf && exec nginx -g 'daemon off;'
+    mkdir -p /etc/nginx/auth
+    echo "logger:$HTPASSWD" > /etc/nginx/auth/htpasswd
+
+    echo 'server {
+      listen       8080;
+      server_name  localhost;
+      location / {
+        default_type text/plain;
+        auth_basic "Restricted";
+        auth_basic_user_file /etc/nginx/auth/htpasswd;  
+        root   /usr/share/nginx/html;
+        autoindex  on;
+      }
+      error_page   500 502 503 504  /50x.html;
+      location = /50x.html {
+        root   /usr/share/nginx/html;
+      }
+    }' > /etc/nginx/conf.d/default.conf
+    exec nginx -g 'daemon off;'
+
 {{ end }}

--- a/stable/htcondor/htcondor/templates/configmap.yaml
+++ b/stable/htcondor/htcondor/templates/configmap.yaml
@@ -16,10 +16,10 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: osg-hosted-ce-{{ .Values.Instance }}-logger-startup
+  name: htcondor-{{ .Values.Instance }}-logger-startup
   labels:
-    app: osg-hosted-ce
-    chart: {{ template "osg-hosted-ce.chart" . }}
+    app: htcondor
+    chart: {{ template "htcondor.chart" . }}
     instance: {{ .Values.Instance }}
     release: {{ .Release.Name }}
 data:

--- a/stable/htcondor/htcondor/templates/configmap.yaml
+++ b/stable/htcondor/htcondor/templates/configmap.yaml
@@ -10,7 +10,6 @@ metadata:
 data:
   condor_config.local: |-
 {{ .Values.CondorConfigFile | indent 4 }}
-{{ end }}
 {{ if .Values.HTTPLogger.Enabled }}
 ---
 apiVersion: v1
@@ -58,5 +57,4 @@ data:
       }
     }' > /etc/nginx/conf.d/default.conf
     exec nginx -g 'daemon off;'
-
 {{ end }}

--- a/stable/htcondor/htcondor/templates/deployment.yaml
+++ b/stable/htcondor/htcondor/templates/deployment.yaml
@@ -81,6 +81,14 @@ spec:
         image: "nginx:1.15.9"
         command: ["/usr/local/bin/start-nginx.sh"]
         imagePullPolicy: IfNotPresent
+        {{ if .Values.HTTPLogger.Secret }}
+        env:
+          - name: HTPASSWD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.HTTPLogger.Secret }}
+                key: HTPASSWD
+        {{ end }}
         ports:
         - name: logs
           containerPort: 8080

--- a/stable/htcondor/htcondor/templates/deployment.yaml
+++ b/stable/htcondor/htcondor/templates/deployment.yaml
@@ -24,6 +24,13 @@ spec:
         instance: {{ .Values.Instance }}
     spec:
       volumes:
+      {{ if .Values.HTTPLogger.Enabled }}
+      - name: log-volume
+        emptyDir: {}
+      - name: logger-startup
+        configMap:
+          name: htcondor-{{ .Values.Instance }}-logger-startup
+      {{ end }}
       - name: executedir
         {{ if .Values.CondorConfig.ExecuteDir }}
         hostPath:
@@ -69,9 +76,28 @@ spec:
       priorityClassName: {{ .Values.CondorConfig.PriorityClass }}
       {{ end }}
       containers:
+      {{ if .Values.HTTPLogger.Enabled }}
+      - name: logging-sidecar
+        image: "nginx:1.15.9"
+        command: ["/usr/local/bin/start-nginx.sh"]
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: logs
+          containerPort: 8080
+          protocol: TCP
+        volumeMounts:
+        - name: log-volume
+          mountPath: /usr/share/nginx/html
+        - name: logger-startup
+          mountPath: /usr/local/bin/start-nginx.sh
+      {{ end }}
       - name: htcondor-worker
         image: slateci/container-condor:latest
         volumeMounts:
+        {{ if .Values.HTTPLogger.Enabled }}
+        - name: log-volume
+          mountPath: /var/log/condor
+        {{ end }}
         - name: executedir
           mountPath: /var/lib/condor/execute
         - name: condor-passwordfile-volume

--- a/stable/htcondor/htcondor/templates/service.yaml
+++ b/stable/htcondor/htcondor/templates/service.yaml
@@ -1,0 +1,21 @@
+{{ if .Values.HTTPLogger.Enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "htcondor.fullname" . }}
+  labels:
+    app: {{ template "htcondor.name" . }}
+    chart: {{ template "htcondor.chart" . }}
+    release: {{ .Release.Name }}
+    instance: {{ .Values.Instance }}
+spec:
+  type: NodePort
+  ports:
+  - port: 8080
+    targetPort: logs
+    protocol: TCP
+    name: logs
+  selector:
+    app: {{ template "htcondor.name" . }}
+    instance: {{ .Values.Instance }}
+{{ end }}

--- a/stable/htcondor/htcondor/values.yaml
+++ b/stable/htcondor/htcondor/values.yaml
@@ -3,6 +3,9 @@
 # Enables unique instances of Frontier Squid in one namespace
 Instance: global
 
+HTTPLogger:
+  Enabled: false
+
 CondorConfig:
   # The number of HTCondor worker pods to run
   Instances: 1

--- a/stable/htcondor/htcondor/values.yaml
+++ b/stable/htcondor/htcondor/values.yaml
@@ -5,6 +5,10 @@ Instance: global
 
 HTTPLogger:
   Enabled: false
+  # You can refer to a password that has been hashed by `openssl passwd -apr1`
+  # and stored as a K8S/SLATE secret here. The resulting credentials will be 
+  # username: logger, and password set to your chosen password.
+  # Secret: my-secret
 
 CondorConfig:
   # The number of HTCondor worker pods to run


### PR DESCRIPTION
This is a working PR for functionality for the HostedCE and HTCondor applications.

I've added two modes of functionaltiy here, the first is that if a user has:
```
# Enable a logging sidecar
HTTPLogger:
  Enabled: true
```
in their configuration, we will auto-generate a password. The user can retrieve that password via `slate instance logs ...` for the logging-sidecar container within their application.

The second functionality is that if a user prefers to create their own password, this can be done via
```
$ openssl passwd -apr1 <password or interactive input>
$ slate secret  create <secret name> --from-literal=HTPASSWD=<resulting hashed password>
```

And configuring the corresponding `HTTPLogger.Secret` in the Values file. 