### PR TITLE
Update HostedCE Service externalTrafficPolicy

### DIFF
--- a/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "8.6.12"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 0.8.1
+version: 0.8.2

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/service.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/service.yaml
@@ -9,6 +9,7 @@ metadata:
     instance: {{ .Values.Instance }}
 spec:
   type: LoadBalancer
+  externalTrafficPolicy: "Local"
   ports:
   - name: htcondor-ce
     port: 9619


### PR DESCRIPTION
With the Local traffic policy, kube-proxy on the node that received the traffic sends it only to the service’s pod(s) that are on the same node. There is no “horizontal” traffic flow between nodes.

Because kube-proxy doesn’t need to send traffic between cluster nodes, your pods can see the real source IP address of incoming connections.

The downside of this policy is that incoming traffic only goes to some pods in the service. Pods that aren’t on the current leader node receive no traffic, they are just there as replicas in case a failover is needed.
