### PR TITLE
Fix daemon contact info

### DIFF
--- a/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "8.6.12"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 0.8.2
+version: 0.8.3

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -67,6 +67,9 @@ metadata:
     release: {{ .Release.Name }}
 data:
   99-instance.conf: |+
+{{ if .Values.Networking.RequestIP }}
+TCP_FORWARDING_HOST = {{ .Values.Networking.RequestIP }}
+{{ end }}
 {{ .Values.HTCondorCeConfig | default "" | indent 4 }}
 {{ if .Values.VomsmapOverride }}
 ---


### PR DESCRIPTION
When clients were contacting the HTCondor-CE, it was giving the daemon's contact info as the private IP address, which a remote client wouldn't be able to resolve. Setting [TCP_FORWARDING_HOST](https://htcondor.readthedocs.io/en/latest/admin-manual/configuration-macros.html#TCP_FORWARDING_HOST) to the requested public IP address forces HTCondor-CE to respond with the daemon's public IP address.