### PR TITLE
Instance tag quoting

### DIFF
--- a/stable/faucet/faucet/Chart.yaml
+++ b/stable/faucet/faucet/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.9.9"
 description: Faucet OpenFlow SDN Controller
 name: faucet
-version: 1.1.9
+version: 1.1.10

--- a/stable/faucet/faucet/templates/configmap.yaml
+++ b/stable/faucet/faucet/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "faucet.name" . }}
     chart: {{ template "faucet.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 data: 
   faucet.yaml: |-
 {{ .Values.Configuration | indent 4 }}

--- a/stable/faucet/faucet/templates/deployment.yaml
+++ b/stable/faucet/faucet/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "faucet.name" . }}
     chart: {{ template "faucet.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 spec:
   replicas: 1
   strategy:
@@ -14,7 +14,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "faucet.name" . }}
-      instance: {{ .Values.Instance }}
+      instance: {{ .Values.Instance | quote }}
   template:
     metadata:
       creationTimestamp: null
@@ -22,7 +22,7 @@ spec:
         app: {{ template "faucet.name" . }}
         chart: {{ template "faucet.chart" . }}
         release: {{ .Release.Name }}
-        instance: {{ .Values.Instance }}
+        instance: {{ .Values.Instance | quote }}
     spec:
       containers:
       - env:

--- a/stable/faucet/faucet/templates/pvc.yaml
+++ b/stable/faucet/faucet/templates/pvc.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "faucet.name" . }}
     chart: {{ template "faucet.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
   name: {{ template "faucet.name" . }}
 spec:
   accessModes:

--- a/stable/faucet/faucet/templates/service.yaml
+++ b/stable/faucet/faucet/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "faucet.name" . }}
     chart: {{ template "faucet.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 spec:
   type: NodePort
   ports:  
@@ -15,6 +15,6 @@ spec:
     targetPort: 6653
   selector:
     app: {{ template "faucet.name" . }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 status:
   loadBalancer: {}

--- a/stable/globus-connect-v4/globus-connect-v4/Chart.yaml
+++ b/stable/globus-connect-v4/globus-connect-v4/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.0.59"
 description: Globus Connect data transfer service
 name: globus-connect-v4
-version: 0.5.9
+version: 0.5.10

--- a/stable/globus-connect-v4/globus-connect-v4/templates/configmap.yaml
+++ b/stable/globus-connect-v4/globus-connect-v4/templates/configmap.yaml
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: globus-{{ .Values.Instance}}-configuration
+  labels:
+    app: {{ template "globus-connect.fullname" . }}
+    chart: {{ template "globus-connect.chart" . }}
+    release: {{ .Release.Name }}
+    instance: {{ .Values.Instance | quote }}
 data:
   globus-connect-server.conf: |-
 {{ .Values.GlobusConfigFile | indent 4 }}

--- a/stable/globus-connect-v4/globus-connect-v4/templates/deployment.yaml
+++ b/stable/globus-connect-v4/globus-connect-v4/templates/deployment.yaml
@@ -11,7 +11,7 @@ spec:
       app: {{ template "globus-connect.fullname" . }}
       chart: {{ template "globus-connect.chart" . }}
       release: {{ .Release.Name }}
-      instance: {{ .Values.Instance }}
+      instance: {{ .Values.Instance | quote }}
   replicas: 1
   template:
     metadata:
@@ -19,12 +19,12 @@ spec:
         app: {{ template "globus-connect.fullname" . }}
         chart: {{ template "globus-connect.chart" . }}
         release: {{ .Release.Name }}
-        instance: {{ .Values.Instance }}
+        instance: {{ .Values.Instance | quote }}
     spec:
       volumes:
       - name: {{ template "globus-connect.fullname" . }}-config
         configMap:
-          name: globus-{{ .Values.Instance }}-configuration
+          name: globus-{{ .Values.Instance | quote }}-configuration
           items:
           - key: globus-connect-server.conf
             path: globus-connect-server.conf

--- a/stable/grafana/grafana/Chart.yaml
+++ b/stable/grafana/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 1.14.8
+version: 1.14.9
 appVersion: 6.0.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/grafana/templates/configmap.yaml
+++ b/stable/grafana/grafana/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 data:
 {{- with .Values.plugins }}
   plugins: {{ . | quote }}

--- a/stable/grafana/grafana/templates/dashboards-json-configmap.yaml
+++ b/stable/grafana/grafana/templates/dashboards-json-configmap.yaml
@@ -9,6 +9,7 @@ metadata:
     app: {{ template "grafana.name" $ }}
     chart: {{ template "grafana.chart" $ }}
     release: {{ $.Release.Name }}
+    instance: {{ .Values.Instance | quote }}
     heritage: {{ $.Release.Service }}
     dashboard-provider: {{ $provider }}
 data:

--- a/stable/grafana/grafana/templates/deployment.yaml
+++ b/stable/grafana/grafana/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 {{- with .Values.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
@@ -19,7 +19,7 @@ spec:
       app: {{ template "grafana.name" . }}
       chart: {{ template "grafana.chart" . }}
       release: {{ .Release.Name }}
-      instance: {{ .Values.Instance }}
+      instance: {{ .Values.Instance | quote }}
   strategy:
     type: RollingUpdate 
   template:
@@ -28,7 +28,7 @@ spec:
         app: {{ template "grafana.name" . }}
         chart: {{ template "grafana.chart" . }}
         release: {{ .Release.Name }}
-        instance: {{ .Values.Instance }}
+        instance: {{ .Values.Instance | quote }}
 {{- with .Values.podAnnotations }}
       annotations:
 {{ toYaml . | indent 8 }}

--- a/stable/grafana/grafana/templates/secret.yaml
+++ b/stable/grafana/grafana/templates/secret.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 type: Opaque
 data:
   admin-user: {{ .Values.adminUser | b64enc | quote }}

--- a/stable/grafana/grafana/templates/service.yaml
+++ b/stable/grafana/grafana/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 {{- if .Values.Service.labels }}
 {{ toYaml .Values.Service.labels | indent 4 }}
 {{- end }}

--- a/stable/gridftp/gridftp/Chart.yaml
+++ b/stable/gridftp/gridftp/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "6.0"
 description: Globus GridFTP data management system 
 name: gridftp
-version: 0.2.15
+version: 0.2.16

--- a/stable/gridftp/gridftp/templates/deployment.yaml
+++ b/stable/gridftp/gridftp/templates/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app: {{ template "gridftp.fullname" . }}
     chart: {{ template "gridftp.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 spec:
   replicas: 1
   selector:
@@ -17,14 +17,14 @@ spec:
       app: {{ template "gridftp.fullname" . }}
       chart: {{ template "gridftp.chart" . }}
       release: {{ .Release.Name }}
-      instance: {{ .Values.Instance }}
+      instance: {{ .Values.Instance | quote }}
   template:
     metadata:
       labels:
         app: {{ template "gridftp.fullname" . }}
         chart: {{ template "gridftp.chart" . }}
         release: {{ .Release.Name }}
-        instance: {{ .Values.Instance }}
+        instance: {{ .Values.Instance | quote }}
     spec:
       hostNetwork: true
       volumes:

--- a/stable/htcondor/htcondor/Chart.yaml
+++ b/stable/htcondor/htcondor/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "8.6.13"
 description: HTCondor distributed high-throughput computing system
 name: htcondor
-version: 0.9.1
+version: 0.9.2

--- a/stable/htcondor/htcondor/templates/configmap.yaml
+++ b/stable/htcondor/htcondor/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "htcondor.name" . }}
     chart: {{ template "htcondor.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 data:
   condor_config.local: |-
 {{ .Values.CondorConfigFile | indent 4 }}
@@ -19,7 +19,7 @@ metadata:
   labels:
     app: htcondor
     chart: {{ template "htcondor.chart" . }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
     release: {{ .Release.Name }}
 data:
   start-nginx.sh: |+

--- a/stable/htcondor/htcondor/templates/deployment.yaml
+++ b/stable/htcondor/htcondor/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "htcondor.fullname" . }}
     chart: {{ template "htcondor.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 spec:
   replicas: {{ .Values.CondorConfig.Instances }}
   selector:
@@ -14,14 +14,14 @@ spec:
       app: {{ template "htcondor.fullname" . }}
       chart: {{ template "htcondor.chart" . }}
       release: {{ .Release.Name }}
-      instance: {{ .Values.Instance }}
+      instance: {{ .Values.Instance | quote }}
   template:
     metadata:
       labels: 
         app: {{ template "htcondor.fullname" . }}
         chart: {{ template "htcondor.chart" . }}
         release: {{ .Release.Name }}
-        instance: {{ .Values.Instance }}
+        instance: {{ .Values.Instance | quote }}
     spec:
       volumes:
       {{ if .Values.HTTPLogger.Enabled }}

--- a/stable/htcondor/htcondor/templates/pvc.yaml
+++ b/stable/htcondor/htcondor/templates/pvc.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: csi-cvmfs-pvc-config-osg-{{ .Values.Instance }}
+  name: {{ printf "csi-cvmfs-pvc-config-osg-%s" .Values.Instance | trimSuffix "-" }}
   labels:
     app: {{ template "htcondor.name" . }}
     chart: {{ template "htcondor.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 spec:
   accessModes:
   - ReadOnlyMany
@@ -18,12 +18,12 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: csi-cvmfs-pvc-connect-{{ .Values.Instance }}
+  name: {{ printf "csi-cvmfs-pvc-connect-%s" .Values.Instance | trimSuffix "-" }}
   labels:
     app: {{ template "htcondor.name" . }}
     chart: {{ template "htcondor.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 spec:
   accessModes:
   - ReadOnlyMany
@@ -35,12 +35,12 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: csi-cvmfs-pvc-oasis-{{ .Values.Instance }}
+  name: {{ printf "csi-cvmfs-pvc-oasis-%s" .Values.Instance | trimSuffix "-" }}
   labels:
     app: {{ template "htcondor.name" . }}
     chart: {{ template "htcondor.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 spec:
   accessModes:
   - ReadOnlyMany
@@ -52,12 +52,12 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: csi-cvmfs-pvc-spt-{{ .Values.Instance }}
+  name: {{ printf "csi-cvmfs-pvc-spt-%s" .Values.Instance | trimSuffix "-" }}
   labels:
     app: {{ template "htcondor.name" . }}
     chart: {{ template "htcondor.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 spec:
   accessModes:
   - ReadOnlyMany
@@ -69,12 +69,12 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: csi-cvmfs-pvc-atlas-{{ .Values.Instance }}
+  name: {{ printf "csi-cvmfs-pvc-atlas-%s" .Values.Instance | trimSuffix "-" }}
   labels:
     app: {{ template "htcondor.name" . }}
     chart: {{ template "htcondor.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 spec:
   accessModes:
   - ReadOnlyMany
@@ -86,12 +86,12 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: csi-cvmfs-pvc-atlas-condb-{{ .Values.Instance }}
+  name: {{ printf "csi-cvmfs-pvc-atlas-condb-%s" .Values.Instance | trimSuffix "-" }}
   labels:
     app: {{ template "htcondor.name" . }}
     chart: {{ template "htcondor.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 spec:
   accessModes:
   - ReadOnlyMany
@@ -103,12 +103,12 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: csi-cvmfs-pvc-atlas-nightlies-{{ .Values.Instance }}
+  name: {{ printf "csi-cvmfs-pvc-atlas-nightlies-%s" .Values.Instance | trimSuffix "-" }}
   labels:
     app: {{ template "htcondor.name" . }}
     chart: {{ template "htcondor.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 spec:
   accessModes:
   - ReadOnlyMany

--- a/stable/htcondor/htcondor/templates/service.yaml
+++ b/stable/htcondor/htcondor/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app: {{ template "htcondor.name" . }}
     chart: {{ template "htcondor.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 spec:
   type: NodePort
   ports:
@@ -17,5 +17,5 @@ spec:
     name: logs
   selector:
     app: {{ template "htcondor.name" . }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 {{ end }}

--- a/stable/minio/minio/Chart.yaml
+++ b/stable/minio/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: MinIO is a high performance distributed object storage server, designed for large-scale private cloud infrastructure.
 name: minio
-version: 2.5.19
+version: 2.5.20
 appVersion: RELEASE.2019-08-07T01-59-21Z
 keywords:
 - storage

--- a/stable/minio/minio/templates/deployment.yaml
+++ b/stable/minio/minio/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: {{ template "minio.name" . }}
     chart: {{ template "minio.chart" . }}
     release: {{ .Release.Name }}
+    instance: {{ .Values.Instance | quote }}
     heritage: {{ .Release.Service }}
 spec:
   strategy:
@@ -42,7 +43,9 @@ spec:
       name: {{ template "minio.fullname" . }}
       labels:
         app: {{ template "minio.name" . }}
+        chart: {{ template "minio.chart" . }}
         release: {{ .Release.Name }}
+        instance: {{ .Values.Instance | quote }}
 {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
 {{- end }}

--- a/stable/minio/minio/templates/ingress.yaml
+++ b/stable/minio/minio/templates/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     app: {{ template "minio.name" . }}
     chart: {{ template "minio.chart" . }}
     release: {{ .Release.Name }}
+    instance: {{ .Values.Instance | quote }}
     heritage: {{ .Release.Service }}
 {{- with .Values.ingress.annotations }}
   annotations:

--- a/stable/minio/minio/templates/networkpolicy.yaml
+++ b/stable/minio/minio/templates/networkpolicy.yaml
@@ -7,6 +7,7 @@ metadata:
     app: {{ template "minio.name" . }}
     chart: {{ template "minio.chart" . }}
     release: {{ .Release.Name }}
+    instance: {{ .Values.Instance | quote }}
     heritage: {{ .Release.Service }}
 spec:
   podSelector:

--- a/stable/minio/minio/templates/pvc.yaml
+++ b/stable/minio/minio/templates/pvc.yaml
@@ -8,6 +8,7 @@ metadata:
     app: {{ template "minio.name" . }}
     chart: {{ template "minio.chart" . }}
     release: {{ .Release.Name }}
+    instance: {{ .Values.Instance | quote }}
     heritage: {{ .Release.Service }}
 spec:
 {{- if and .Values.nasgateway.enabled .Values.nasgateway.pv }}

--- a/stable/minio/minio/templates/service.yaml
+++ b/stable/minio/minio/templates/service.yaml
@@ -6,6 +6,7 @@ metadata:
     app: {{ template "minio.name" . }}
     chart: {{ template "minio.chart" . }}
     release: {{ .Release.Name }}
+    instance: {{ .Values.Instance | quote }}
     heritage: {{ .Release.Service }}
 {{- if .Values.service.annotations }}
   annotations:
@@ -41,3 +42,4 @@ spec:
   selector:
     app: {{ template "minio.name" . }}
     release: {{ .Release.Name }}
+    instance: {{ .Values.Instance | quote }}

--- a/stable/minio/minio/templates/serviceaccount.yaml
+++ b/stable/minio/minio/templates/serviceaccount.yaml
@@ -4,4 +4,9 @@ kind: ServiceAccount
 metadata:
   name: {{ include "minio.serviceAccountName" . | quote }}
   namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    instance: {{ .Values.Instance | quote }}
 {{- end -}}

--- a/stable/minio/minio/templates/statefulset.yaml
+++ b/stable/minio/minio/templates/statefulset.yaml
@@ -8,6 +8,7 @@ metadata:
     app: {{ template "minio.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
+    instance: {{ .Values.Instance | quote }}
     heritage: "{{ .Release.Service }}"
 spec:
   clusterIP: None
@@ -26,6 +27,7 @@ metadata:
     app: {{ template "minio.name" . }}
     chart: {{ template "minio.chart" . }}
     release: {{ .Release.Name }}
+    instance: {{ .Values.Instance | quote }}
     heritage: {{ .Release.Service }}
 spec:
   updateStrategy:
@@ -37,12 +39,14 @@ spec:
     matchLabels:
       app: {{ template "minio.name" . }}
       release: {{ .Release.Name }}
+      instance: {{ .Values.Instance | quote }}
   template:
     metadata:
       name: {{ template "minio.fullname" . }}
       labels:
         app: {{ template "minio.name" . }}
         release: {{ .Release.Name }}
+        instance: {{ .Values.Instance | quote }}
 {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
 {{- end }}

--- a/stable/nginx/nginx/Chart.yaml
+++ b/stable/nginx/nginx/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: "v1"
 name: "nginx"
-version: 1.1.3
+version: 1.1.4
 appVersion: 1.15.9
 description: "A simple nginx deployment which serves a static page"

--- a/stable/nginx/nginx/templates/configmap.yaml
+++ b/stable/nginx/nginx/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "nginx.name" . }}
     chart: {{ template "nginx.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 data:
   index.html: |-
 {{ .Values.Data | indent 4 }}

--- a/stable/nginx/nginx/templates/deployment.yaml
+++ b/stable/nginx/nginx/templates/deployment.yaml
@@ -6,20 +6,20 @@ metadata:
     app: {{ template "nginx.name" . }}
     chart: {{ template "nginx.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: {{ template "nginx.name" . }}
-      instance: {{ .Values.Instance }}
+      instance: {{ .Values.Instance | quote }}
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
         app: {{ template "nginx.name" . }}
         chart: {{ template "nginx.chart" . }}
-        instance: {{ .Values.Instance }}
+        instance: {{ .Values.Instance | quote }}
         release: {{ .Release.Name }}
     spec:
       containers:

--- a/stable/nginx/nginx/templates/service.yaml
+++ b/stable/nginx/nginx/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "nginx.name" . }}
     chart: {{ template "nginx.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 spec:
   type: NodePort
   ports:
@@ -16,7 +16,7 @@ spec:
     protocol: TCP
   selector:
     app: {{ template "nginx.name" . }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 ---
 {{ if .Values.Ingress.Enabled }}
 apiVersion: extensions/v1beta1
@@ -27,7 +27,7 @@ metadata:
     app: {{ template "nginx.name" . }}
     chart: {{ template "nginx.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
   annotations:
     kubernetes.io/ingress.class: {{ .Values.Ingress.Class }}
 spec:

--- a/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
@@ -5,4 +5,4 @@ appVersion: 4.4-2.1
 description: A Helm chart for configuration and deployment of the Open Science Grid's Frontier Squid application.
 name: osg-frontier-squid
 # Chart version
-version: 1.2.0
+version: 1.2.1

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "osg-frontier-squid.name" . }}
     chart: {{ template "osg-frontier-squid.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 
 spec:
   replicas: 1
@@ -15,7 +15,7 @@ spec:
       app: {{ template "osg-frontier-squid.name" . }}
       chart: {{ template "osg-frontier-squid.chart" . }}
       release: {{ .Release.Name }}
-      instance: {{ .Values.Instance }}
+      instance: {{ .Values.Instance | quote }}
 
   template:
     metadata:
@@ -23,7 +23,7 @@ spec:
         app: {{ template "osg-frontier-squid.name" . }}
         chart: {{ template "osg-frontier-squid.chart" . }}
         release: {{ .Release.Name }}
-        instance: {{ .Values.Instance }}
+        instance: {{ .Values.Instance | quote }}
     spec:
       # Required affinity for using local storage
       {{ if .Values.SLATE.LocalStorage }}

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/pvc.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/pvc.yaml
@@ -3,6 +3,11 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: osg-frontier-squid-{{ .Values.Instance }}-pvc
+  labels:
+    app: {{ template "osg-frontier-squid.name" . }}
+    chart: {{ template "osg-frontier-squid.chart" . }}
+    release: {{ .Release.Name }}
+    instance: {{ .Values.Instance | quote }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/service.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "osg-frontier-squid.name" . }}
     chart: {{ template "osg-frontier-squid.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 spec:
   type: {{ .Values.Service.ExternalVisibility }}
   {{ if ne .Values.Service.ExternalVisibility "ClusterIP" }}
@@ -16,7 +16,7 @@ spec:
     app: {{ template "osg-frontier-squid.name" . }}
     chart: {{ template "osg-frontier-squid.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
   ports:
   - port: {{ .Values.Service.Port }}
     targetPort: squid

--- a/stable/perfsonar-testpoint/perfsonar-testpoint/Chart.yaml
+++ b/stable/perfsonar-testpoint/perfsonar-testpoint/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.2.0"
 description: Perfsonar Testpoint Deployment
 name: perfsonar-testpoint
-version: 1.0.9
+version: 1.0.10

--- a/stable/perfsonar-testpoint/perfsonar-testpoint/templates/deployment.yaml
+++ b/stable/perfsonar-testpoint/perfsonar-testpoint/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "perfsonar-testpoint.name" . }}
     chart: {{ template "perfsonar-testpoint.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 spec:
   replicas: 1
   selector:
@@ -14,7 +14,7 @@ spec:
       app: {{ template "perfsonar-testpoint.name" . }}
       chart: {{ template "perfsonar-testpoint.chart" . }}
       release: {{ .Release.Name }}
-      instance: {{ .Values.Instance }}
+      instance: {{ .Values.Instance | quote }}
   strategy:
     type: Recreate
   template:
@@ -24,7 +24,7 @@ spec:
         app: {{ template "perfsonar-testpoint.name" . }}
         chart: {{ template "perfsonar-testpoint.chart" . }}
         release: {{ .Release.Name }}
-        instance: {{ .Values.Instance }}
+        instance: {{ .Values.Instance | quote }}
     spec:
       hostNetwork: true
       privileged: true

--- a/stable/stashcache/stashcache/Chart.yaml
+++ b/stable/stashcache/stashcache/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: stashcache
 # Chart version
-version: 0.1.11
+version: 0.1.12
 description: StashCache is an XRootD-based caching service
 # Version of application packaged for installation
 appVersion: "v4.10.0-rc5"

--- a/stable/stashcache/stashcache/templates/configmap.yaml
+++ b/stable/stashcache/stashcache/templates/configmap.yaml
@@ -52,5 +52,5 @@ metadata:
     app: {{ template "stashcache.name" . }}
     chart: {{ template "stashcache.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 

--- a/stable/stashcache/stashcache/templates/deployment.yaml
+++ b/stable/stashcache/stashcache/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "stashcache.name" . }}
     chart: {{ template "stashcache.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 spec:
   replicas: 1
   selector:
@@ -14,14 +14,14 @@ spec:
       app: {{ template "stashcache.name" . }}
       chart: {{ template "stashcache.chart" . }}
       release: {{ .Release.Name }}
-      instance: {{ .Values.Instance }}
+      instance: {{ .Values.Instance | quote }}
   template:
     metadata:
       labels:
         app: {{ template "stashcache.name" . }}
         chart: {{ template "stashcache.chart" . }}
         release: {{ .Release.Name }}
-        instance: {{ .Values.Instance }}
+        instance: {{ .Values.Instance | quote }}
     spec:
       volumes:
       - name: stashcache-config

--- a/stable/stashcache/stashcache/templates/service.yaml
+++ b/stable/stashcache/stashcache/templates/service.yaml
@@ -6,14 +6,14 @@ metadata:
     app: {{ template "stashcache.name" . }}
     chart: {{ template "stashcache.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 spec:
   type: NodePort
   selector:
     app: {{ template "stashcache.name" . }}
     chart: {{ template "stashcache.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
   ports:
     - protocol: TCP
       name: xrootd

--- a/stable/xcache/xcache/Chart.yaml
+++ b/stable/xcache/xcache/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: xcache
 # Chart version
-version: 0.2.9
+version: 0.2.10
 description: XCache is a xrootd based caching service for k8s
 # Version of application packaged for installation
 appVersion: "4.11"

--- a/stable/xcache/xcache/templates/deployment.yaml
+++ b/stable/xcache/xcache/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "xcache.name" . }}
     chart: {{ template "xcache.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 spec:
   replicas: 1
   selector:
@@ -14,7 +14,7 @@ spec:
       app: {{ template "xcache.name" . }}
       chart: {{ template "xcache.chart" . }}
       release: {{ .Release.Name }}
-      instance: {{ .Values.Instance }}
+      instance: {{ .Values.Instance | quote }}
     
   template:
     metadata:
@@ -22,7 +22,7 @@ spec:
         app: {{ template "xcache.name" . }}
         chart: {{ template "xcache.chart" . }}
         release: {{ .Release.Name }}
-        instance: {{ .Values.Instance }}
+        instance: {{ .Values.Instance | quote }}
     spec:
 
       nodeSelector:

--- a/stable/xcache/xcache/templates/service.yaml
+++ b/stable/xcache/xcache/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "xcache.name" . }}
     chart: {{ template "xcache.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}
 spec:
   type: NodePort
   ports:
@@ -21,4 +21,4 @@ spec:
     app: {{ template "xcache.name" . }}
     chart: {{ template "xcache.chart" . }}
     release: {{ .Release.Name }}
-    instance: {{ .Values.Instance }}
+    instance: {{ .Values.Instance | quote }}


### PR DESCRIPTION
These patches ensure that all of the stable catalog applications work with empty string and numeric instance tags (issue #47). 