### PR TITLE
fixed cmd/args, fixed subpath

### DIFF
--- a/stable/htcondor/htcondor/Chart.yaml
+++ b/stable/htcondor/htcondor/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "8.6.13"
 description: HTCondor distributed high-throughput computing system
 name: htcondor
-version: 0.9.2
+version: 0.9.3

--- a/stable/htcondor/htcondor/templates/deployment.yaml
+++ b/stable/htcondor/htcondor/templates/deployment.yaml
@@ -79,7 +79,8 @@ spec:
       {{ if .Values.HTTPLogger.Enabled }}
       - name: logging-sidecar
         image: "nginx:1.15.9"
-        command: ["/usr/local/bin/start-nginx.sh"]
+        command: ["/bin/bash"]
+        args: ["/usr/local/bin/start-nginx.sh"]
         imagePullPolicy: IfNotPresent
         {{ if .Values.HTTPLogger.Secret }}
         env:
@@ -98,6 +99,7 @@ spec:
           mountPath: /usr/share/nginx/html
         - name: logger-startup
           mountPath: /usr/local/bin/start-nginx.sh
+          subPath: start-nginx.sh
       {{ end }}
       - name: htcondor-worker
         image: slateci/container-condor:latest


### PR DESCRIPTION
I have no idea how these slipped past the first time.

The first change is because Kubernetes will not set the mode correctly on the startup script. We'll need to have the shell invoke it.

The second change will actually pick out the script and place it into the container, rather than creating a directory containing the script. 