### PR TITLE
Add support for a secret containing a pre-existing host cert and key

### DIFF
--- a/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "8.6.12"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 0.8.5
+version: 0.9.0

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -47,6 +47,18 @@ spec:
           - key: bosco.key
             path: bosco.key
             mode: 256
+      {{ if .Values.Certificate.Secret }}
+      - name: osg-hosted-ce-{{ .Values.Instance }}-hostcertkeypair
+        secret:
+          secretName: {{ .Values.Certificate.Secret }}
+          items:
+            - key: hostcert.pem
+              path: hostcert.pem
+              mode: 256
+            - key: hostkey.pem
+              path: hostkey.pem
+              mode: 256
+      {{end}}
       {{ if .Values.BoscoOverrides.Enabled }}
       {{ if .Values.BoscoOverrides.RepoNeedsPrivKey }}
       - name: osg-hosted-ce-{{ .Values.Instance }}-gitkey
@@ -113,6 +125,14 @@ spec:
         - name: osg-hosted-ce-{{ .Values.Instance }}-htcondor-ce-configuration
           mountPath: /etc/condor-ce/config.d/99-instance.conf
           subPath: 99-instance.conf
+        {{ if .Values.Certificate.Secret }}
+        - name: osg-hosted-ce-{{ .Values.Instance }}-hostcert
+          mountPath: /etc/grid-security/hostcert.pem
+          subPath: hostcert.pem
+        - name: osg-hosted-ce-{{ .Values.Instance }}-hostkey
+          mountPath: /etc/grid-security/hostkey.pem
+          subPath: hostkey.pem
+        {{ end }}
         {{ if .Values.HTTPLogger.Enabled }}
         - name: log-volume
           mountPath: /var/log/condor-ce

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
           - key: bosco.key
             path: bosco.key
             mode: 256
-      {{ if .Values.Certificate.Secret }}
+      {{ if .Values.Certificate.Enabled }}
       - name: osg-hosted-ce-{{ .Values.Instance }}-hostcertkeypair
         secret:
           secretName: {{ .Values.Certificate.Secret }}
@@ -125,7 +125,7 @@ spec:
         - name: osg-hosted-ce-{{ .Values.Instance }}-htcondor-ce-configuration
           mountPath: /etc/condor-ce/config.d/99-instance.conf
           subPath: 99-instance.conf
-        {{ if .Values.Certificate.Secret }}
+        {{ if .Values.Certificate.Enabled }}
         - name: osg-hosted-ce-{{ .Values.Instance }}-hostcert
           mountPath: /etc/grid-security/hostcert.pem
           subPath: hostcert.pem

--- a/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -90,6 +90,12 @@ VomsmapOverride: |+
 #GridmapOverride: |+
 #  "/DC=foo/DC=bar/OU=Organic Units/OU=Users/CN=YourUserName" osg
 
+# Use a pre-existing certificate/key pair stored in a secret with
+# 'hostcert.pem' and 'hostkey.pem' keys for the host certificate and
+# key, respectively
+# Certificate:
+#  Secret: my-secret
+
 # FOR DEVELOPMENT PURPOSES ONLY!
 # Setting 'Enabled: true' below does the following:
 # - Configures the CE as an ITB host

--- a/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -93,8 +93,8 @@ VomsmapOverride: |+
 # Use a pre-existing certificate/key pair stored in a secret with
 # 'hostcert.pem' and 'hostkey.pem' keys for the host certificate and
 # key, respectively
- Certificate:
-   Enabled: false
+Certificate:
+  Enabled: false
 #  Secret: my-secret
 
 # FOR DEVELOPMENT PURPOSES ONLY!

--- a/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -93,7 +93,8 @@ VomsmapOverride: |+
 # Use a pre-existing certificate/key pair stored in a secret with
 # 'hostcert.pem' and 'hostkey.pem' keys for the host certificate and
 # key, respectively
-# Certificate:
+ Certificate:
+   Enabled: false
 #  Secret: my-secret
 
 # FOR DEVELOPMENT PURPOSES ONLY!


### PR DESCRIPTION
I'm not sure if the `{{ if .Values.Certificate.Secret }}` stuff will work or if we need to do something like `{{ if .Values.Certificate.Enabled }}` and add `Enabled: false` to the values file