### PR TITLE
Add node name affinity to osg-frontier-squid

### DIFF
--- a/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
@@ -5,4 +5,4 @@ appVersion: 4.4-2.1
 description: A Helm chart for configuration and deployment of the Open Science Grid's Frontier Squid application.
 name: osg-frontier-squid
 # Chart version
-version: 1.2.1
+version: 1.2.2

--- a/stable/osg-frontier-squid/osg-frontier-squid/README.md
+++ b/stable/osg-frontier-squid/osg-frontier-squid/README.md
@@ -22,5 +22,14 @@ $ slate app install osg-frontier-squid --group <group-name> --cluster <cluster-n
 | CacheMem | The amount of memory that Squid may use for caching hot objects | `128 MB` |
 | CacheSize | The amount of disk space that Squid may use for caching cold objects | `10000 MB` |
 | IPRange | A space separated list of source address CIDRs that can access the cache. **NOTE** Incorrectly specifying this may lead to open proxies on your network! | `10.0.0.0/8 172.16.0.0/12 192.168.0.0/16` |  
+| Hostname |FQDN for the cluster node you want this instance to schedule on | `null` |
+
+&ast;```Hostname``` is nested under ```NodeSelection```:
+
+```
+NodeSelection:
+  Hostname: null
+```
+
 ### Usage
 For more instructions on how to use OSG Frontier Squid please read this [documentation](https://opensciencegrid.org/docs/data/frontier-squid/)

--- a/stable/osg-frontier-squid/osg-frontier-squid/README.md
+++ b/stable/osg-frontier-squid/osg-frontier-squid/README.md
@@ -22,7 +22,7 @@ $ slate app install osg-frontier-squid --group <group-name> --cluster <cluster-n
 | CacheMem | The amount of memory that Squid may use for caching hot objects | `128 MB` |
 | CacheSize | The amount of disk space that Squid may use for caching cold objects | `10000 MB` |
 | IPRange | A space separated list of source address CIDRs that can access the cache. **NOTE** Incorrectly specifying this may lead to open proxies on your network! | `10.0.0.0/8 172.16.0.0/12 192.168.0.0/16` |  
-| Hostname |FQDN for the cluster node you want this instance to schedule on | `null` |
+| Hostname&ast; |FQDN for the cluster node you want this instance to schedule on | `null` |
 
 &ast;```Hostname``` is nested under ```NodeSelection```:
 

--- a/stable/osg-frontier-squid/osg-frontier-squid/README.md
+++ b/stable/osg-frontier-squid/osg-frontier-squid/README.md
@@ -22,14 +22,7 @@ $ slate app install osg-frontier-squid --group <group-name> --cluster <cluster-n
 | CacheMem | The amount of memory that Squid may use for caching hot objects | `128 MB` |
 | CacheSize | The amount of disk space that Squid may use for caching cold objects | `10000 MB` |
 | IPRange | A space separated list of source address CIDRs that can access the cache. **NOTE** Incorrectly specifying this may lead to open proxies on your network! | `10.0.0.0/8 172.16.0.0/12 192.168.0.0/16` |  
-| Hostname&ast; |FQDN for the cluster node you want this instance to schedule on | `null` |
-
-&ast;```Hostname``` is nested under ```NodeSelection```:
-
-```
-NodeSelection:
-  Hostname: null
-```
+| NodeSelection.Hostname |FQDN for the cluster node you want this instance to schedule on | `null` |
 
 ### Usage
 For more instructions on how to use OSG Frontier Squid please read this [documentation](https://opensciencegrid.org/docs/data/frontier-squid/)

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
@@ -31,8 +31,8 @@ spec:
         storage: "local"
         {{ end }}
         # For Node Selection
-        {{ if .Values.DesiredNode }}
-        kubernetes.io/hostname: "{{ .Values.DesiredNode }}"
+        {{ if .Values.NodeSelection.Hostname }}
+        kubernetes.io/hostname: {{ .Values.NodeSelection.Hostname }}
         {{ end }}
       containers:
       # Container for the primary application, OSG Frontier Squid

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
@@ -25,11 +25,15 @@ spec:
         release: {{ .Release.Name }}
         instance: {{ .Values.Instance | quote }}
     spec:
-      # Required affinity for using local storage
-      {{ if .Values.SLATE.LocalStorage }}
       nodeSelector:
+        # Required affinity for using local storage
+        {{ if .Values.SLATE.LocalStorage }}
         storage: "local"
-      {{ end }}
+        {{ end }}
+        # For Node Selection
+        {{ if .Values.DesiredNode }}
+        kubernetes.io/hostname: "{{ .Values.DesiredNode }}"
+        {{ end }}
       containers:
       # Container for the primary application, OSG Frontier Squid
       - name: osg-frontier-squid

--- a/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
@@ -43,7 +43,7 @@ SquidConf:
   # within kubernetes clusters. 
   IPRange: 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16
   
-  # Hostname for the cluster node you want this instance to schedule on.
+  # Hostname (FQDN) for the cluster node you want this instance to schedule on.
   # This will also be the hostname used to access the squid if ExternalVisibility is set to NodePort
   # Set this to null to be randomly assigned an available node
   DesiredNode: null

--- a/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
@@ -42,3 +42,8 @@ SquidConf:
   # The default set of ranges are those defined in RFC 1918 and typically used 
   # within kubernetes clusters. 
   IPRange: 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16
+  
+  # Hostname for the cluster node you want this instance to schedule on.
+  # This will also be the hostname used to access the squid if ExternalVisibility is set to NodePort
+  # Set this to null to be randomly assigned an available node
+  DesiredNode: null

--- a/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
@@ -46,4 +46,5 @@ SquidConf:
   # Hostname (FQDN) for the cluster node you want this instance to schedule on.
   # This will also be the hostname used to access the squid if ExternalVisibility is set to NodePort
   # Set this to null to be randomly assigned an available node
-  DesiredNode: null
+NodeSelection:  
+  Hostname: null


### PR DESCRIPTION
This patch will allow users of the osg-frontier-squid chart to specify which node they want this application to schedule on.

No node affinity
```
NodeSelection:
  Hostname: null
```

Requesting a specific host
```
NodeSelection:
  Hostname: node.example.com
```
