### PR TITLE
Use a static name for the host cert/key pair volume name

### DIFF
--- a/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "8.6.12"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 0.10.2
+version: 0.10.3

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
             path: bosco.key
             mode: 256
       {{ if .Values.Certificate.Secret }}
-      - name: osg-hosted-ce-{{ .Values.Instance }}-hostcertkeypair
+      - name: osg-hosted-ce-hostcertkeypair-volume
         secret:
           secretName: {{ .Values.Certificate.Secret }}
           items:
@@ -126,10 +126,10 @@ spec:
           mountPath: /etc/condor-ce/config.d/99-instance.conf
           subPath: 99-instance.conf
         {{ if .Values.Certificate.Secret }}
-        - name: osg-hosted-ce-{{ .Values.Instance }}-hostcert
+        - name: osg-hosted-ce-hostcertkeypair-volume
           mountPath: /etc/grid-security/hostcert.pem
           subPath: hostcert.pem
-        - name: osg-hosted-ce-{{ .Values.Instance }}-hostkey
+        - name: osg-hosted-ce-hostcertkeypair-volume
           mountPath: /etc/grid-security/hostkey.pem
           subPath: hostkey.pem
         {{ end }}


### PR DESCRIPTION
@Mansalu @LincolnBryant I'm not sure how the existing host cert/key stuff works without this change. Because with an instance name of `blin-test-ce` I get the following error:

```
Failed to install application osg-hosted-ce: Failed to start application instance with helm:
[exit] 1
[err]: Error: Deployment.apps "osg-hosted-ce-blin-test-ce" is invalid: [spec.template.spec.containers[1].volumeMounts[3].name: Not found: "osg-hosted-ce-blin-test-ce-hostcert", spec.template.spec.containers[1].volumeMounts[4].name: Not found: "osg-hosted-ce-blin-test-ce-hostkey"]
```