### PR TITLE
Fix Open Science CE event errors

### DIFF
--- a/incubator/open-science-ce/open-science-ce/Chart.yaml
+++ b/incubator/open-science-ce/open-science-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.2.1"
 description: An OSG Submit Host that accepts remote job submission through HTCondor-CE
 name: open-science-ce
-version: 0.1.2
+version: 0.1.3

--- a/incubator/open-science-ce/open-science-ce/templates/configmap.yaml
+++ b/incubator/open-science-ce/open-science-ce/templates/configmap.yaml
@@ -158,7 +158,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: open-science-ce-{{ .Values.Instance }}-configuration
+  name: open-science-ce-{{ .Values.Instance }}-condor-configuration
   labels:
     app: open-science-ce
     chart: {{ template "open-science-ce.chart" . }}

--- a/incubator/open-science-ce/open-science-ce/templates/deployment.yaml
+++ b/incubator/open-science-ce/open-science-ce/templates/deployment.yaml
@@ -71,9 +71,9 @@ spec:
           - key: condor_token
             path: condor_token
             mode: 256
-      - name: {{ template "open-science-ce.name" . }}-condor-configuration
+      - name: open-science-ce-{{ .Values.Instance }}}-condor-configuration
         configMap:
-          name: {{ template "open-science-ce.name" . }}-condor-configuration
+          name: open-science-ce-{{ .Values.Instance }}-condor-configuration
       initContainers:
       - name: condor-spool-init
         image: opensciencegrid/submit-host:fresh

--- a/incubator/open-science-ce/open-science-ce/templates/deployment.yaml
+++ b/incubator/open-science-ce/open-science-ce/templates/deployment.yaml
@@ -24,9 +24,6 @@ spec:
         instance: {{ .Values.Instance | quote }}
     spec:
       volumes:
-      - name: open-science-ce-{{ .Values.Instance }}-spool
-        configMap:
-          name: open-science-ce-{{ .Values.Instance }}-spool
       - name: open-science-ce-{{ .Values.Instance }}-osg-configuration
         configMap:
           name: open-science-ce-{{ .Values.Instance }}-osg-configuration
@@ -78,7 +75,7 @@ spec:
         configMap:
           name: {{ template "open-science-ce.name" . }}-condor-configuration
       initContainers:
-      - name: condor-spool-volume
+      - name: condor-spool-init
         image: opensciencegrid/submit-host:fresh
         imagePullPolicy: Always
         command: ['/bin/chown','condor:condor','/var/lib/condor/spool']


### PR DESCRIPTION
```
[2020-04-02T15:21:43Z - 2020-04-02T15:22:47Z] FailedMount: MountVolume.SetUp failed for volume "open-science-ce-blin-spool" : configmap "open-science-ce-blin-spool" not found (x8)

[2020-04-02T15:21:44Z - 2020-04-02T15:22:48Z] FailedMount: MountVolume.SetUp failed for volume "blin-condor-configuration" : configmap "blin-condor-configuration" not found (x8)
```