### PR TITLE
Use the external hostname for advertising

### DIFF
--- a/incubator/open-science-ce/open-science-ce/Chart.yaml
+++ b/incubator/open-science-ce/open-science-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.2.1"
 description: An OSG Submit Host that accepts remote job submission through HTCondor-CE
 name: open-science-ce
-version: 0.1.11
+version: 0.1.12

--- a/incubator/open-science-ce/open-science-ce/templates/configmap.yaml
+++ b/incubator/open-science-ce/open-science-ce/templates/configmap.yaml
@@ -188,6 +188,8 @@ data:
 {{ if .Values.Networking.Hostname }}
     # Force HTCondor to use the requested hostname
     NETWORK_HOSTNAME = {{ .Values.Networking.Hostname }}
+    # For a given CE, use the same token trust domain between instances
+    TRUST_DOMAIN = {{ .Values.Networking.Hostname }}
 {{ end }}
 {{ if .Values.Networking.RequestIP }}
     TCP_FORWARDING_HOST = {{ .Values.Networking.RequestIP }}

--- a/incubator/open-science-ce/open-science-ce/templates/configmap.yaml
+++ b/incubator/open-science-ce/open-science-ce/templates/configmap.yaml
@@ -182,6 +182,8 @@ data:
     # Force container daemons to talk over the container IP
     PRIVATE_NETWORK_NAME = $(UTSNAME_NODENAME)
     PRIVATE_NETWORK_INTERFACE = $(IP_ADDRESS)
+    # Tell local daemons to contact the collector via container hostname
+    COLLECTOR_HOST = $(UTSNAME_NODENAME)
 {{ if .Values.Networking.Hostname }}
     # Force HTCondor to use the requested hostname
     NETWORK_HOSTNAME = {{ .Values.Networking.Hostname }}

--- a/incubator/open-science-ce/open-science-ce/templates/configmap.yaml
+++ b/incubator/open-science-ce/open-science-ce/templates/configmap.yaml
@@ -71,9 +71,8 @@ metadata:
     release: {{ .Release.Name }}
 data:
   99-instance.conf: |+
-    # Allow the CE to find the local schedd ad using the container hostname
+    # Allow the CE to communicate with the local collector via pod IP
     JOB_ROUTER_SCHEDD2_POOL = $(UTSNAME_NODENAME):9618
-    JOB_ROUTER_SCHEDD2_NAME = $(UTSNAME_NODENAME)@$(UTSNAME_NODENAME)
     # Force container daemons to talk over the container IP
     PRIVATE_NETWORK_NAME = $(UTSNAME_NODENAME)
     PRIVATE_NETWORK_INTERFACE = $(IP_ADDRESS)
@@ -180,8 +179,6 @@ data:
   condor_config.local: |+
     # Allow the CE to route jobs as the mapped user
     QUEUE_SUPER_USER_MAY_IMPERSONATE = .*
-    # Allow the CE to find the local schedd ad using the container hostname
-    SCHEDD_NAME = $(UTSNAME_NODENAME)@$(UTSNAME_NODENAME)
     # Force container daemons to talk over the container IP
     PRIVATE_NETWORK_NAME = $(UTSNAME_NODENAME)
     PRIVATE_NETWORK_INTERFACE = $(IP_ADDRESS)

--- a/incubator/open-science-ce/open-science-ce/templates/configmap.yaml
+++ b/incubator/open-science-ce/open-science-ce/templates/configmap.yaml
@@ -78,6 +78,8 @@ data:
     PRIVATE_NETWORK_NAME = $(UTSNAME_NODENAME)
     PRIVATE_NETWORK_INTERFACE = $(IP_ADDRESS)
 {{ if .Values.Networking.Hostname }}
+    # Force HTCondor to use the requested hostname
+    NETWORK_HOSTNAME = {{ .Values.Networking.Hostname }}
     # For a given CE, use the same token trust domain between instances
     TRUST_DOMAIN = {{ .Values.Networking.Hostname }}
 {{ end }}
@@ -183,6 +185,10 @@ data:
     # Force container daemons to talk over the container IP
     PRIVATE_NETWORK_NAME = $(UTSNAME_NODENAME)
     PRIVATE_NETWORK_INTERFACE = $(IP_ADDRESS)
+{{ if .Values.Networking.Hostname }}
+    # Force HTCondor to use the requested hostname
+    NETWORK_HOSTNAME = {{ .Values.Networking.Hostname }}
+{{ end }}
 {{ if .Values.Networking.RequestIP }}
     TCP_FORWARDING_HOST = {{ .Values.Networking.RequestIP }}
 {{ end }}


### PR DESCRIPTION
This gives us a consistent host name across instances 