### PR TITLE
Set the appropriate match expression for payload records

### DIFF
--- a/incubator/open-science-ce/open-science-ce/Chart.yaml
+++ b/incubator/open-science-ce/open-science-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.2.1"
 description: An OSG Submit Host that accepts remote job submission through HTCondor-CE
 name: open-science-ce
-version: 0.1.14
+version: 0.1.15

--- a/incubator/open-science-ce/open-science-ce/templates/configmap.yaml
+++ b/incubator/open-science-ce/open-science-ce/templates/configmap.yaml
@@ -76,6 +76,12 @@ data:
     # Force container daemons to talk over the container IP
     PRIVATE_NETWORK_NAME = $(UTSNAME_NODENAME)
     PRIVATE_NETWORK_INTERFACE = $(IP_ADDRESS)
+    JOB_ROUTER_DEFAULTS @=jrd
+    $(JOB_ROUTER_DEFAULTS)
+    [
+      set_JOBGLIDEIN_ResourceName = "$$([IfThenElse(IsUndefined(TARGET.GLIDEIN_ResourceName), IfThenElse(IsUndefined(TARGET.GLIDEIN_Site), \"Local Job\", TARGET.GLIDEIN_Site), TARGET.GLIDEIN_ResourceName)])";
+    ]
+    @jrd
 {{ if .Values.Networking.Hostname }}
     # Force HTCondor to use the requested hostname
     NETWORK_HOSTNAME = {{ .Values.Networking.Hostname }}


### PR DESCRIPTION
We want to treat jobs submitted to the Open Science CE and routed to
the OSG submit host as payload jobs. Gratia depends on the match
expression to differentiate between payload and pilot jobs.