### PR TITLE
 i think the logic was inverted here, attempting a fix

### DIFF
--- a/stable/globus-connect-v4/images/globus-connect-v4/supervisord_startup.sh
+++ b/stable/globus-connect-v4/images/globus-connect-v4/supervisord_startup.sh
@@ -34,10 +34,14 @@ fi
 # check for a globus_server defined as an environment variable. if we get one,
 # check to see if it has a port attached. if there is, comment out the default
 # port so globus can do whatever with its gridftp.d file
-if [ -z $GLOBUS_SERVER ]; then
+if [ -z ${GLOBUS_SERVER+x} ]; then
+  echo "GLOBUS_SERVER is undefined"
+else
   GLOBUS_PORT=$(echo $GLOBUS_SERVER | cut -d':' -f2 -s)
   # if we actually get a port out of that, then comment out the gridftp defualt
-  if [ -z $GLOBUS_PORT ]; then
+  if [ -z ${GLOBUS_PORT+x} ]; then
+    echo "Globus port is undefined, assume defaults"
+  else
     sed -i 's/port/#port/' /etc/gridftp.conf
   fi
 fi

--- a/stable/globus-connect-v4/images/globus-connect-v4/supervisord_startup.sh
+++ b/stable/globus-connect-v4/images/globus-connect-v4/supervisord_startup.sh
@@ -34,12 +34,12 @@ fi
 # check for a globus_server defined as an environment variable. if we get one,
 # check to see if it has a port attached. if there is, comment out the default
 # port so globus can do whatever with its gridftp.d file
-if [ -z ${GLOBUS_SERVER+x} ]; then
+if [ -z "$GLOBUS_SERVER" ]; then
   echo "GLOBUS_SERVER is undefined"
 else
-  GLOBUS_PORT=$(echo $GLOBUS_SERVER | cut -d':' -f2 -s)
+  GLOBUS_PORT=$(echo "$GLOBUS_SERVER" | cut -d':' -f2 -s)
   # if we actually get a port out of that, then comment out the gridftp defualt
-  if [ -z ${GLOBUS_PORT} ]; then
+  if [ -z "$GLOBUS_PORT" ]; then
     echo "Globus port is an empty string, assume defaults"
   else
     sed -i 's/port/#port/' /etc/gridftp.conf

--- a/stable/globus-connect-v4/images/globus-connect-v4/supervisord_startup.sh
+++ b/stable/globus-connect-v4/images/globus-connect-v4/supervisord_startup.sh
@@ -39,8 +39,8 @@ if [ -z ${GLOBUS_SERVER+x} ]; then
 else
   GLOBUS_PORT=$(echo $GLOBUS_SERVER | cut -d':' -f2 -s)
   # if we actually get a port out of that, then comment out the gridftp defualt
-  if [ -z ${GLOBUS_PORT+x} ]; then
-    echo "Globus port is undefined, assume defaults"
+  if [ -z ${GLOBUS_PORT} ]; then
+    echo "Globus port is an empty string, assume defaults"
   else
     sed -i 's/port/#port/' /etc/gridftp.conf
   fi


### PR DESCRIPTION
if `GLOBUS_SERVER` is EMPTY we want to do NOTHING, but if it's got something in it we:
  want to comment out the default port IF the `GLOBUS_PORT` is a nonempty string.

