### PR TITLE
make the server nonempty

### DIFF
--- a/stable/globus-connect-v4/globus-connect-v4/Chart.yaml
+++ b/stable/globus-connect-v4/globus-connect-v4/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.0.59"
 description: Globus Connect data transfer service
 name: globus-connect-v4
-version: 0.6.2
+version: 0.6.3

--- a/stable/globus-connect-v4/globus-connect-v4/templates/configmap.yaml
+++ b/stable/globus-connect-v4/globus-connect-v4/templates/configmap.yaml
@@ -40,4 +40,5 @@ data:
     {{ else }}
     Server = %(HOSTNAME)s
     {{ end }}
+    Server = %(HOSTNAME)s
     {{ end }}


### PR DESCRIPTION
The stupid nesting makes this kinda blow up in a weird way. Need to set `Server =` if the MyProxy section is uncommented, AND if `MyProxy.Server` is uncommented. We should comeup with a better fix later..