### PR TITLE
Add the ability to use a pre-generated host key

### DIFF
--- a/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "8.6.12"
+appVersion: "4.2.1"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
 version: 1.1.10

--- a/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.2.1"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 1.1.10
+version: 2.0.0

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -47,15 +47,21 @@ spec:
           - key: bosco.key
             path: bosco.key
             mode: 256
-      {{ if .Values.Certificate.Secret }}
-      - name: osg-hosted-ce-hostcertkeypair-volume
+      {{ if .Values.HostCredentials.HostCertSecret }}
+      - name: osg-hosted-ce-hostcert-volume
         secret:
-          secretName: {{ .Values.Certificate.Secret }}
+          secretName: {{ .Values.HostCredentials.HostCertSecret }}
           items:
-            - key: hostcert.pem
+            - key: host.cert
               path: hostcert.pem
               mode: 256
-            - key: hostkey.pem
+      {{end}}
+      {{ if .Values.HostCredentials.HostKeySecret }}
+      - name: osg-hosted-ce-hostkey-volume
+        secret:
+          secretName: {{ .Values.HostCredentials.HostKeySecret }}
+          items:
+            - key: host.key
               path: hostkey.pem
               mode: 256
       {{end}}
@@ -129,11 +135,13 @@ spec:
         - name: osg-hosted-ce-{{ .Values.Instance }}-htcondor-ce-configuration
           mountPath: /etc/condor-ce/config.d/99-instance.conf
           subPath: 99-instance.conf
-        {{ if .Values.Certificate.Secret }}
-        - name: osg-hosted-ce-hostcertkeypair-volume
+        {{ if .Values.HostCredentials.HostCertSecret }}
+        - name: osg-hosted-ce-hostcert-volume
           mountPath: /etc/grid-security/hostcert.pem
           subPath: hostcert.pem
-        - name: osg-hosted-ce-hostcertkeypair-volume
+        {{ end }}
+        {{ if .Values.HostCredentials.HostKeySecret }}
+        - name: osg-hosted-ce-hostkey-volume
           mountPath: /etc/grid-security/hostkey.pem
           subPath: hostkey.pem
         {{ end }}

--- a/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -95,11 +95,18 @@ VomsmapOverride: |+
 #GridmapOverride: |+
 #  "/DC=foo/DC=bar/OU=Organic Units/OU=Users/CN=YourUserName" osg
 
-# Use a pre-existing certificate/key pair stored in a secret with
-# 'hostcert.pem' and 'hostkey.pem' keys for the host certificate and
-# key, respectively
-Certificate:
-  Secret: null
+HostCredentials:
+  # Use a pre-existing host key to request a new Let's Encrypt
+  # certificate If HostCertSecret is also specified, the Let's Encrypt
+  # request is skipped.  Secret must contain a "host.key" key
+  # containing the encoded host key.
+  HostKeySecret: null
+  # Use a pre-existing host certificate instead of requesting a new
+  # Let'S Encrypt certificate. If HostKeySecret is not specified, a
+  # new Let's Encrypt certificate and key are requested anyway.
+  # Secret must contain a "host.key containing the encoded host
+  # certificate.
+  HostCertSecret: null
 
 # FOR DEVELOPMENT PURPOSES ONLY!
 # Setting 'Enabled: true' below does the following:


### PR DESCRIPTION
With the latest `fresh` container, this change allows the user to provide their own key and get a Let's Encrypt cert. They can then get the cert out of the instance logs and store it in a host cert secret.

Submitting as a draft PR because I'd like to update the `README`.