### PR TITLE
Simplify Hosted CE remote user config (SOFTWARE-3960)

### DIFF
--- a/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.2.1"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 2.0.1
+version: 3.0.0

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -34,7 +34,7 @@ data:
 
     [Subcluster {{ .Values.Topology.Resource }}]
     name = {{ .Values.Topology.Resource }}
-    ram_mb = {{ .Values.RemoteCluster.Memory }}
+    ram_mb = {{ .Values.RemoteCluster.MemoryPerNode }}
     cores_per_node = {{ .Values.RemoteCluster.CoresPerNode }}
     max_wall_time = {{ .Values.RemoteCluster.MaxWallTime }}
     allowed_vos = *

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -16,16 +16,16 @@ data:
     group = OSG
     {{ end }}
     host_name = localhost
-    resource = {{ .Values.Site.Resource }}
-    resource_group = {{ .Values.Site.ResourceGroup }}
-    sponsor = {{ .Values.Site.Sponsor }}
+    resource = {{ .Values.Topology.Resource }}
+    resource_group = {{ .Values.Topology.ResourceGroup }}
+    sponsor = {{ .Values.Topology.Sponsor }}
     site_policy = UNAVAILABLE
-    contact = {{ .Values.Site.Contact }}
-    email = {{ .Values.Site.ContactEmail }}
-    city = {{ .Values.Site.City }}
-    country = {{ .Values.Site.Country }}
-    latitude = {{ .Values.Site.Latitude }}
-    longitude = {{ .Values.Site.Longitude }}
+    contact = {{ .Values.Topology.Contact }}
+    email = {{ .Values.Topology.ContactEmail }}
+    city = {{ .Values.Topology.City }}
+    country = {{ .Values.Topology.Country }}
+    latitude = {{ .Values.Topology.Latitude }}
+    longitude = {{ .Values.Topology.Longitude }}
 
     [BOSCO]
     enabled = False
@@ -42,8 +42,8 @@ data:
     data_dir = None
     worker_node_temp = {{ .Values.RemoteCluster.WorkerNodeTemp }}
 
-    [Subcluster {{ .Values.Site.Resource }}]
-    name = {{ .Values.Site.Resource }}
+    [Subcluster {{ .Values.Topology.Resource }}]
+    name = {{ .Values.Topology.Resource }}
     ram_mb = {{ .Values.RemoteCluster.Memory }}
     cores_per_node = {{ .Values.RemoteCluster.CoresPerNode }}
     max_wall_time = {{ .Values.RemoteCluster.MaxWallTime }}

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -71,6 +71,7 @@ data:
 
     JOB_ROUTER_ENTRIES = [Name = "Hosted_CE_default_route"]
 
+    JOB_ROUTER_ROUTE_NAMES = Hosted_CE_default_route
     # Operator-provided HTCondor-CE configuration below this line
 {{ .Values.HTCondorCeConfig | default "" | indent 4 }}
 ---

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -115,6 +115,32 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  name: osg-hosted-ce-{{ .Values.Instance }}-voms-mapfile-default
+  labels:
+    app: osg-hosted-ce
+    chart: {{ template "osg-hosted-ce.chart" . }}
+    instance: {{ .Values.Instance }}
+    release: {{ .Release.Name }}
+data:
+  voms-mapfile-default: |+
+    "/osg/Role=NULL/Capability=NULL" osg
+    "/GLOW/Role=htpc/Capability=NULL" glow
+    "/hcc/Role=NULL/Capability=NULL" hcc
+    "/cms/*" cms
+    "/fermilab/*" fnal
+    "/osg/ligo/Role=NULL/Capability=NULL" ligo
+    "/virgo/ligo/Role=NULL/Capability=NULL" virgo
+    "/sdcc/Role=NULL/Capability=NULL" sdcc
+    "/sphenix/Role=NULL/Capability=NULL" sphenix
+    "/atlas/*" atlas
+    "/Gluex/Role=NULL/Capability=NULL" gluex
+    "/dune/Role=pilot/Capability=NULL" dune
+    "/icecube/Role=pilot/Capability=NULL" icecube
+    "/xenon.biggrid.nl/Role=NULL/Capability=NULL" xenon
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
   name: osg-hosted-ce-{{ .Values.Instance }}-grid-mapfile
   labels:
     app: osg-hosted-ce

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -37,6 +37,7 @@ data:
     ram_mb = {{ .Values.RemoteCluster.Memory }}
     cores_per_node = {{ .Values.RemoteCluster.CoresPerNode }}
     max_wall_time = {{ .Values.RemoteCluster.MaxWallTime }}
+    allowed_vos = *
 
     [Squid]
     {{ if .Values.RemoteCluster.Squid }}

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -62,10 +62,14 @@ data:
     TCP_FORWARDING_HOST = {{ .Values.Networking.RequestIP }}
 {{ end }}
 
+    # HACK: The job router doesn't recognize grid universe routes (the default) without
+    # a "GridResource" attribute and the Gridmanager doesn't evaluate GridResource expressions.
+    # So we set a dummy "GridResource" attribute and use "eval_set_GridResource"  to force the
     JOB_ROUTER_DEFAULTS @=jrd
     $(JOB_ROUTER_DEFAULTS)
     [
-    GridResource = strcat("batch ", "{{ .Values.RemoteCluster.Batch }} ", Owner, "@", "{{ .Values.RemoteCluster.LoginHost }}");
+    GridResource = "intentionally left blank";
+    eval_set_GridResource = strcat("batch ", "{{ .Values.RemoteCluster.Batch }} ", Owner, "@", "{{ .Values.RemoteCluster.LoginHost }}");
     ]
     @jrd
 

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -19,7 +19,6 @@ data:
     resource = {{ .Values.Topology.Resource }}
     resource_group = {{ .Values.Topology.ResourceGroup }}
     sponsor = {{ .Values.Topology.Sponsor }}
-    site_policy = UNAVAILABLE
     contact = {{ .Values.Topology.Contact }}
     email = {{ .Values.Topology.ContactEmail }}
     city = {{ .Values.Topology.City }}
@@ -30,16 +29,8 @@ data:
     [BOSCO]
     enabled = False
 
-    [Misc Services]
-    edit_lcmaps_db = True
-    authorization_method = vomsmap
-
     [Storage]
-    se_available = False
-    default_se = None
     grid_dir = {{ .Values.RemoteCluster.GridDir }}
-    app_dir = UNSET
-    data_dir = None
     worker_node_temp = {{ .Values.RemoteCluster.WorkerNodeTemp }}
 
     [Subcluster {{ .Values.Topology.Resource }}]
@@ -47,7 +38,6 @@ data:
     ram_mb = {{ .Values.RemoteCluster.Memory }}
     cores_per_node = {{ .Values.RemoteCluster.CoresPerNode }}
     max_wall_time = {{ .Values.RemoteCluster.MaxWallTime }}
-    allowed_vos = {{- range $key, $val := .Values.Cluster.VoRemoteUserMapping }} {{ $key }}, {{- end }}
 
     [Squid]
     {{ if .Values.RemoteCluster.Squid }}
@@ -56,9 +46,6 @@ data:
     enabled = False
     {{ end }}
     location =  {{ .Values.RemoteCluster.Squid }}
-    policy = DEFAULT
-    cache_size = DEFAULT
-    memory_size = DEFAULT
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -74,6 +74,26 @@ data:
 {{ if .Values.Networking.RequestIP }}
     TCP_FORWARDING_HOST = {{ .Values.Networking.RequestIP }}
 {{ end }}
+
+    JOB_ROUTER_CLASSAD_USER_MAP_NAMES = REMOTE_USER
+    CLASSAD_USER_MAPFILE_REMOTE_USER = /etc/condor-ce/remote_user_mapfile
+
+    JOB_ROUTER_DEFAULTS @=jrd
+    $(JOB_ROUTER_DEFAULTS)
+    [
+    GridResource = strcat("batch ", "{{ .Values.Cluster.RemoteBatch }}", userMap(REMOTE_USER, Owner, "", Owner), "@", "{{ .Values.Cluster.RemoteHost }}");
+    ]
+    @jrd
+
+    JOB_ROUTER_SOURCE_JOB_CONSTRAINT = $(JOB_ROUTER_SOURCE_JOB_CONSTRAINT) && userMap(REMOTE_USER, Owner, "")
+
+    JOB_ROUTER_ENTRIES @=jre
+    [
+    Name = "Hosted_CE_default_route";
+    Requirements = True;
+    ]
+
+    # Operator-provided HTCondor-CE configuration below this line
 {{ .Values.HTCondorCeConfig | default "" | indent 4 }}
 {{ if .Values.VomsmapOverride }}
 ---

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -37,25 +37,25 @@ data:
     [Storage]
     se_available = False
     default_se = None
-    grid_dir = {{ .Values.Storage.GridDir }}
+    grid_dir = {{ .Values.RemoteCluster.GridDir }}
     app_dir = UNSET
     data_dir = None
-    worker_node_temp = {{ .Values.Storage.WorkerNodeTemp }}
+    worker_node_temp = {{ .Values.RemoteCluster.WorkerNodeTemp }}
 
     [Subcluster {{ .Values.Site.Resource }}]
     name = {{ .Values.Site.Resource }}
-    ram_mb = {{ .Values.Cluster.Memory }}
-    cores_per_node = {{ .Values.Cluster.CoresPerNode }}
-    max_wall_time = {{ .Values.Cluster.MaxWallTime }}
+    ram_mb = {{ .Values.RemoteCluster.Memory }}
+    cores_per_node = {{ .Values.RemoteCluster.CoresPerNode }}
+    max_wall_time = {{ .Values.RemoteCluster.MaxWallTime }}
     allowed_vos = {{- range $key, $val := .Values.Cluster.VoRemoteUserMapping }} {{ $key }}, {{- end }}
 
     [Squid]
-    {{ if .Values.Squid.Location }}
+    {{ if .Values.RemoteCluster.Squid }}
     enabled = True
     {{ else }}
     enabled = False
     {{ end }}
-    location =  {{ .Values.Squid.Location }}
+    location =  {{ .Values.RemoteCluster.Squid }}
     policy = DEFAULT
     cache_size = DEFAULT
     memory_size = DEFAULT

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -69,10 +69,7 @@ data:
     ]
     @jrd
 
-    JOB_ROUTER_ENTRIES @=jre
-    [
-    Name = "Hosted_CE_default_route";
-    ]
+    JOB_ROUTER_ENTRIES = [Name = "Hosted_CE_default_route"]
 
     # Operator-provided HTCondor-CE configuration below this line
 {{ .Values.HTCondorCeConfig | default "" | indent 4 }}

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -17,7 +17,6 @@ data:
     {{ end }}
     host_name = localhost
     resource = {{ .Values.Topology.Resource }}
-    resource_group = {{ .Values.Topology.ResourceGroup }}
     sponsor = {{ .Values.Topology.Sponsor }}
     contact = {{ .Values.Topology.Contact }}
     email = {{ .Values.Topology.ContactEmail }}

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -65,7 +65,7 @@ data:
     JOB_ROUTER_DEFAULTS @=jrd
     $(JOB_ROUTER_DEFAULTS)
     [
-    GridResource = strcat("batch ", "{{ .Values.RemoteCluster.Batch }}", Owner, "@", "{{ .Values.RemoteCluster.LoginHost }}");
+    GridResource = strcat("batch ", "{{ .Values.RemoteCluster.Batch }} ", Owner, "@", "{{ .Values.RemoteCluster.LoginHost }}");
     ]
     @jrd
 

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -47,7 +47,7 @@ data:
     ram_mb = {{ .Values.Cluster.Memory }}
     cores_per_node = {{ .Values.Cluster.CoresPerNode }}
     max_wall_time = {{ .Values.Cluster.MaxWallTime }}
-    allowed_vos = {{ .Values.Cluster.AllowedVOs }}
+    allowed_vos = {{- range $key, $val := .Values.Cluster.VoRemoteUserMapping }} {{ $key }}, {{- end }}
 
     [Squid]
     {{ if .Values.Squid.Location }}
@@ -75,27 +75,20 @@ data:
     TCP_FORWARDING_HOST = {{ .Values.Networking.RequestIP }}
 {{ end }}
 
-    JOB_ROUTER_CLASSAD_USER_MAP_NAMES = REMOTE_USER
-    CLASSAD_USER_MAPFILE_REMOTE_USER = /etc/condor-ce/remote_user_mapfile
-
     JOB_ROUTER_DEFAULTS @=jrd
     $(JOB_ROUTER_DEFAULTS)
     [
-    GridResource = strcat("batch ", "{{ .Values.Cluster.RemoteBatch }}", userMap(REMOTE_USER, Owner, "", Owner), "@", "{{ .Values.Cluster.RemoteHost }}");
+    GridResource = strcat("batch ", "{{ .Values.RemoteCluster.Batch }}", Owner, "@", "{{ .Values.RemoteCluster.LoginHost }}");
     ]
     @jrd
-
-    JOB_ROUTER_SOURCE_JOB_CONSTRAINT = $(JOB_ROUTER_SOURCE_JOB_CONSTRAINT) && userMap(REMOTE_USER, Owner, "")
 
     JOB_ROUTER_ENTRIES @=jre
     [
     Name = "Hosted_CE_default_route";
-    Requirements = True;
     ]
 
     # Operator-provided HTCondor-CE configuration below this line
 {{ .Values.HTCondorCeConfig | default "" | indent 4 }}
-{{ if .Values.VomsmapOverride }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -108,35 +101,12 @@ metadata:
     release: {{ .Release.Name }}
 data:
   voms-mapfile: |+
-{{ .Values.VomsmapOverride | indent 4 }}
-{{ end }}
-{{ if .Values.GridmapOverride }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: osg-hosted-ce-{{ .Values.Instance }}-voms-mapfile-default
-  labels:
-    app: osg-hosted-ce
-    chart: {{ template "osg-hosted-ce.chart" . }}
-    instance: {{ .Values.Instance }}
-    release: {{ .Release.Name }}
-data:
-  voms-mapfile-default: |+
-    "/osg/Role=NULL/Capability=NULL" osg
-    "/GLOW/Role=htpc/Capability=NULL" glow
-    "/hcc/Role=NULL/Capability=NULL" hcc
-    "/cms/*" cms
-    "/fermilab/*" fnal
-    "/osg/ligo/Role=NULL/Capability=NULL" ligo
-    "/virgo/ligo/Role=NULL/Capability=NULL" virgo
-    "/sdcc/Role=NULL/Capability=NULL" sdcc
-    "/sphenix/Role=NULL/Capability=NULL" sphenix
-    "/atlas/*" atlas
-    "/Gluex/Role=NULL/Capability=NULL" gluex
-    "/dune/Role=pilot/Capability=NULL" dune
-    "/icecube/Role=pilot/Capability=NULL" icecube
-    "/xenon.biggrid.nl/Role=NULL/Capability=NULL" xenon
+    {{- range $index, $map := .Values.VoRemoteUserMapping }}
+    {{- range $voms, $user := $map }}
+    {{ $voms | quote }} {{ $user }}
+    {{- end }}
+    {{- end }}
+{{ if .Values.DnRemoteUserMapping }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -149,7 +119,11 @@ metadata:
     release: {{ .Release.Name }}
 data:
   grid-mapfile: |+
-{{ .Values.GridmapOverride | indent 4 }}
+    {{- range $index, $map := .Values.DnRemoteUserMapping }}
+    {{- range $dn, $user := $map }}
+    {{ $dn | quote }} {{ $user }}
+    {{- end}}
+    {{- end }}
 {{ end }}
 {{ if .Values.HTTPLogger.Enabled }}
 ---

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
       - name: osg-hosted-ce-{{ .Values.Instance }}-htcondor-ce-configuration
         configMap:
           name: osg-hosted-ce-{{ .Values.Instance }}-htcondor-ce-configuration
+      - name: osg-hosted-ce-{{ .Values.Instance }}-voms-mapfile-default
+        configMap:
+          name: osg-hosted-ce-{{ .Values.Instance }}-voms-mapfile-default
       {{ if .Values.VomsmapOverride }}
       - name: osg-hosted-ce-{{ .Values.Instance }}-voms-mapfile
         configMap:
@@ -154,6 +157,9 @@ spec:
           mountPath: /etc/osg/git.key
           subPath: git.key
         {{ end }}
+        - name: osg-hosted-ce-{{ .Values.Instance }}-voms-mapfile-default
+          mountPath: /usr/share/osg/voms-mapfile-default
+          subPath: voms-mapfile-default
         {{ if .Values.VomsmapOverride }}
         - name: osg-hosted-ce-{{ .Values.Instance }}-voms-mapfile
           mountPath: /etc/grid-security/voms-mapfile

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -190,7 +190,7 @@ spec:
         - name: REMOTE_HOST
           value: {{ .Values.RemoteCluster.LoginHost }}
         - name: REMOTE_BATCH
-          value: {{ .Values.RemoteCluster.Batch }}
+          value: {{ .Values.RemoteCluster.Batch | lower }}
         - name: DEVELOPER
           {{ if .Values.Developer.Enabled }}  # https://github.com/helm/helm/issues/2848
           value: "true"

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
       {{ end }}
       - name: bosco-ssh-private-key-volume
         secret: 
-          secretName: {{ .Values.Cluster.PrivateKeySecret }}
+          secretName: {{ .Values.RemoteCluster.PrivateKeySecret }}
           items:
           - key: bosco.key
             path: bosco.key
@@ -188,9 +188,11 @@ spec:
         - name: RESOURCE_NAME
           value: {{ .Values.Site.Resource }}
         - name: REMOTE_HOST
-          value: {{ .Values.Cluster.RemoteHost }}
+          value: {{ .Values.RemoteCluster.LoginHost }}
         - name: REMOTE_BATCH
-          value: {{ .Values.Cluster.RemoteBatch }}
+          value: {{ .Values.RemoteCluster.Batch }}
+        - name: REMOTE_OS_VER
+          value: {{ .Values.RemoteCluster.OperatingSystem }}
         - name: DEVELOPER
           {{ if .Values.Developer.Enabled }}  # https://github.com/helm/helm/issues/2848
           value: "true"

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -184,9 +184,9 @@ spec:
           value: {{ .Values.Networking.Hostname }}
         {{ end }}
         - name: CE_CONTACT
-          value: {{ .Values.Site.ContactEmail }}
+          value: {{ .Values.Topology.ContactEmail }}
         - name: RESOURCE_NAME
-          value: {{ .Values.Site.Resource }}
+          value: {{ .Values.Topology.Resource }}
         - name: REMOTE_HOST
           value: {{ .Values.RemoteCluster.LoginHost }}
         - name: REMOTE_BATCH
@@ -201,7 +201,7 @@ spec:
         - name: BOSCO_GIT_ENDPOINT
           value: {{ .Values.BoscoOverrides.GitEndpoint }}
         - name: BOSCO_DIRECTORY
-          value: {{ .Values.Site.Resource }}
+          value: {{ .Values.Topology.Resource }}
         {{ end }}
         lifecycle:
           preStop:

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
               mode: 256
       {{end}}
       {{ if .Values.BoscoOverrides.Enabled }}
-      {{ if .Values.BoscoOverrides.RepoNeedsPrivKey }}
+      {{ if .Values.BoscoOverrides.GitKeySecret }}
       - name: osg-hosted-ce-{{ .Values.Instance }}-gitkey
         secret:
           secretName: {{ .Values.BoscoOverrides.GitKeySecret }}

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -30,15 +30,10 @@ spec:
       - name: osg-hosted-ce-{{ .Values.Instance }}-htcondor-ce-configuration
         configMap:
           name: osg-hosted-ce-{{ .Values.Instance }}-htcondor-ce-configuration
-      - name: osg-hosted-ce-{{ .Values.Instance }}-voms-mapfile-default
-        configMap:
-          name: osg-hosted-ce-{{ .Values.Instance }}-voms-mapfile-default
-      {{ if .Values.VomsmapOverride }}
       - name: osg-hosted-ce-{{ .Values.Instance }}-voms-mapfile
         configMap:
           name: osg-hosted-ce-{{ .Values.Instance }}-voms-mapfile
-      {{ end }}
-      {{ if .Values.GridmapOverride }}
+      {{ if .Values.DnRemoteUserMapping }}
       - name: osg-hosted-ce-{{ .Values.Instance }}-grid-mapfile
         configMap:
           name: osg-hosted-ce-{{ .Values.Instance }}-grid-mapfile
@@ -157,15 +152,10 @@ spec:
           mountPath: /etc/osg/git.key
           subPath: git.key
         {{ end }}
-        - name: osg-hosted-ce-{{ .Values.Instance }}-voms-mapfile-default
-          mountPath: /usr/share/osg/voms-mapfile-default
-          subPath: voms-mapfile-default
-        {{ if .Values.VomsmapOverride }}
         - name: osg-hosted-ce-{{ .Values.Instance }}-voms-mapfile
           mountPath: /etc/grid-security/voms-mapfile
           subPath: voms-mapfile
-        {{ end }}
-        {{ if .Values.GridmapOverride }}
+        {{ if .Values.DnRemoteUserMapping }}
         - name: osg-hosted-ce-{{ .Values.Instance }}-grid-mapfile
           mountPath: /etc/grid-security/grid-mapfile
           subPath: grid-mapfile

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -191,8 +191,6 @@ spec:
           value: {{ .Values.RemoteCluster.LoginHost }}
         - name: REMOTE_BATCH
           value: {{ .Values.RemoteCluster.Batch }}
-        - name: REMOTE_OS_VER
-          value: {{ .Values.RemoteCluster.OperatingSystem }}
         - name: DEVELOPER
           {{ if .Values.Developer.Enabled }}  # https://github.com/helm/helm/issues/2848
           value: "true"

--- a/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -12,24 +12,24 @@ Site:
   Latitude: 0.00
   Longitude: 0.00
 
-Cluster:
-  RemoteHost: remote-ssh.login.org
-  RemoteBatch: slurm
+RemoteCluster:
+  # SSH host
+  LoginHost: remote-ssh.login.org
   PrivateKeySecret: lincolnb-bosco # maps to SLATE secret
+  # condor, slurm, pbs, sge, or lsf
+  Batch: slurm
   Memory: 1024
   CoresPerNode: 4
   MaxWallTime: 1440
-
-# Do NOT use environment variables for any of the Storage variables
-Storage:
   # Absolute path to the local WN client installation
+  # Do not use environment variables!
   GridDir: /home/osguser/bosco-osg-wn-client
+  # Worker node scratch space for payload jobs
+  # Do not use environment variables!
   WorkerNodeTemp: /tmp
+  # <IP OR FQDN>:<PORT> for the site's local squid server
+  Squid: null
 
-Squid:
-  # <IP OR HOSTNAME>:<PORT> for the site's local squid server
-  Location: null
-  
 Networking:
   ServiceType: "LoadBalancer"
   # The hostname that the CE should use. 

--- a/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -95,7 +95,6 @@ VoRemoteUserMapping:
 BoscoOverrides:
   Enabled: false
   GitEndpoint: https://github.com/slateci/bosco-override-template
-  RepoNeedsPrivKey: false
   GitKeySecret: null
 
 # Enable a logging sidecar

--- a/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -61,23 +61,10 @@ HTTPLogger:
   # point Secret to a K8S/SLATE secret below.
   # Secret: my-secret
 
-# Default VO-user mappings for OSG Hosted CEs
+# VOMS FQAN-user mappings for OSG Hosted CEs
+# https://opensciencegrid.org/docs/security/lcmaps-voms-authentication/#mapping-vos
 # Change these contents for legacy OSG Hosted CEs or non-OSG Hosted CEs
-VomsmapOverride: |+
-   "/osg/Role=NULL/Capability=NULL" osg01
-   "/GLOW/Role=htpc/Capability=NULL" osg02
-   "/hcc/Role=NULL/Capability=NULL" osg03
-   "/cms/*" osg04
-   "/fermilab/*" osg05
-   "/osg/ligo/Role=NULL/Capability=NULL" osg07
-   "/virgo/ligo/Role=NULL/Capability=NULL" osg07
-   "/sdcc/Role=NULL/Capability=NULL" osg08
-   "/sphenix/Role=NULL/Capability=NULL" osg08
-   "/atlas/*" osg09
-   "/Gluex/Role=NULL/Capability=NULL" osg10
-   "/dune/Role=pilot/Capability=NULL" osg11
-   "/icecube/Role=pilot/Capability=NULL" osg12
-   "/xenon.biggrid.nl/Role=NULL/Capability=NULL" osg13
+# VomsmapOverride: |+
 
 # If you wish to allow yourself to submit to this CE with your personal grid
 # proxy, you can put that in below. This will get directly mapped into

--- a/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -19,7 +19,6 @@ Cluster:
   Memory: 1024
   CoresPerNode: 4
   MaxWallTime: 1440
-  AllowedVOs: osg, cms, atlas, glow, hcc, fermilab, ligo, virgo, sdcc, sphenix, gluex, icecube, xenon
 
 # Do NOT use environment variables for any of the Storage variables
 Storage:
@@ -42,6 +41,51 @@ Networking:
   # back the same IP address that was used previously. 
   RequestIP: null
 
+# VOMS FQAN to remote user mapping
+# This list controls the VOs accepted by the CE and the users they are
+# mapped to on the remote site.
+#
+# To disallow VOs, remove the relevant item from the list.
+# To change the remote user for a given VO, change the value (e.g. osg01)
+# To add custom VOMS FQAN mappings, add a new item to the list.
+# VOMS FQANs can include "*" wildcards.
+VoRemoteUserMapping:
+  # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/OSG.yaml
+  - "/osg/Role=NULL/Capability=NULL": osg01
+  # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/GLOW.yaml
+  - "/GLOW/Role=htpc/Capability=NULL": osg02
+  # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/HCC.yaml
+  - "/hcc/Role=NULL/Capability=NULL": osg03
+  # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/CMS.yaml
+  - "/cms/*": osg04
+  # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/Fermilab.yaml
+  - "/fermilab/*": osg05
+  # osg06 reserved for JLAB
+  # LIGO-Virgo collaboration
+  # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/LIGO.yaml
+  - "/osg/ligo/Role=NULL/Capability=NULL": osg07
+  - "/virgo/ligo/Role=NULL/Capability=NULL": osg07
+  # Brookhaven National Lab VOs
+  # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/sPHENIX.yaml
+  - "/sdcc/Role=NULL/Capability=NULL": osg08
+  - "/sphenix/Role=NULL/Capability=NULL": osg08
+  # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/ATLAS.yaml
+  - "/atlas/*": osg09
+  # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/Gluex.yaml
+  - "/Gluex/Role=NULL/Capability=NULL": osg10
+  # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/DUNE.yaml
+  - "/dune/Role=pilot/Capability=NULL": osg11
+  # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/IceCube.yaml
+  - "/icecube/Role=pilot/Capability=NULL": osg12
+  # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/XENON.yaml
+  - "/xenon.biggrid.nl/Role=NULL/Capability=NULL": osg13
+
+# DN to remote user mapping
+# For example, you may add your personal certificate's subject DN so
+# that you can submit jobs to this CE
+#DnRemoteUserMapping:
+#  - "/DC=foo/DC=bar/OU=Organic Units/OU=Users/CN=YourUserName": osg01
+
 # Specify additional HTCondor-CE configuration
 # HTCondorCeConfig: |+
 
@@ -60,18 +104,6 @@ HTTPLogger:
   # If you want to insert a password instead of using a randomly generated one,
   # point Secret to a K8S/SLATE secret below.
   # Secret: my-secret
-
-# VOMS FQAN-user mappings for OSG Hosted CEs
-# https://opensciencegrid.org/docs/security/lcmaps-voms-authentication/#mapping-vos
-# Change these contents for legacy OSG Hosted CEs or non-OSG Hosted CEs
-# VomsmapOverride: |+
-
-# If you wish to allow yourself to submit to this CE with your personal grid
-# proxy, you can put that in below. This will get directly mapped into
-# /etc/grid-security/grid-mapfile
-#
-#GridmapOverride: |+
-#  "/DC=foo/DC=bar/OU=Organic Units/OU=Users/CN=YourUserName" osg
 
 HostCredentials:
   # Use a pre-existing host key to request a new Let's Encrypt

--- a/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -15,7 +15,8 @@ Topology:
 RemoteCluster:
   # SSH host
   LoginHost: remote-ssh.login.org
-  PrivateKeySecret: lincolnb-bosco # maps to SLATE secret
+  # SLATE secret with 'bosco.key' containing the SSH key to access LoginHost:
+  PrivateKeySecret: lincolnb-bosco
   # condor, slurm, pbs, sge, or lsf
   Batch: slurm
   Memory: 1024
@@ -88,6 +89,7 @@ VoRemoteUserMapping:
 
 # Specify additional HTCondor-CE configuration
 # HTCondorCeConfig: |+
+#   ALL_DEBUG = D_ALWAYS:2 D_CAT
 
 # Options to allow override of the bosco directory from arbitrary git repos
 # Bosco override dirs are expected in the following location in the git repo:
@@ -95,6 +97,9 @@ VoRemoteUserMapping:
 BoscoOverrides:
   Enabled: false
   GitEndpoint: https://github.com/slateci/bosco-override-template
+  # If GitEndpoint requires authentication, create a SLATE secret with
+  # 'git.key' containing the private SSH key that can access
+  # it. Specify the name of the secret in GitKeySecret:
   GitKeySecret: null
 
 # Enable a logging sidecar

--- a/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -18,7 +18,7 @@ RemoteCluster:
   PrivateKeySecret: lincolnb-bosco
   # condor, slurm, pbs, sge, or lsf
   Batch: slurm
-  Memory: 1024
+  MemoryPerNode: 1024
   CoresPerNode: 4
   MaxWallTime: 1440
   # Absolute path to the local WN client installation

--- a/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -122,7 +122,7 @@ HostCredentials:
   # Use a pre-existing host certificate instead of requesting a new
   # Let'S Encrypt certificate. If HostKeySecret is not specified, a
   # new Let's Encrypt certificate and key are requested anyway.
-  # Secret must contain a "host.key containing the encoded host
+  # Secret must contain a "host.cert" containing the encoded host
   # certificate.
   HostCertSecret: null
 

--- a/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -1,11 +1,11 @@
 Instance: ""
 
 # Site information that should match the CE Topology registration
-Site:
+Topology:
   Resource: RESOURCE_NAME
-  ResourceGroup: Resource Group
+  ResourceGroup: RESOURCE_GROUP
   Sponsor: osg:100
-  Contact: Resource Contact
+  Contact: RESOURCE_CONTACT
   ContactEmail: support@example.edu
   City: City
   Country: US

--- a/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -27,7 +27,7 @@ RemoteCluster:
   # Worker node scratch space for payload jobs
   # Do not use environment variables!
   WorkerNodeTemp: /tmp
-  # <IP OR FQDN>:<PORT> for the site's local squid server
+  # <IP OR FQDN>:<PORT> for the site's local squid server, or 'null' if no site Squid
   Squid: null
 
 Networking:

--- a/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -81,6 +81,10 @@ VoRemoteUserMapping:
   # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/XENON.yaml
   - "/xenon.biggrid.nl/Role=NULL/Capability=NULL": osg13
 
+##########################
+# OPTIONAL CONFIGURATION #
+##########################
+
 # DN to remote user mapping
 # For example, you may add your personal certificate's subject DN so
 # that you can submit jobs to this CE

--- a/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -42,17 +42,8 @@ Networking:
   # back the same IP address that was used previously. 
   RequestIP: null
 
-########### REQUIRED ###########
-# Specify additional HTCondor-CE configuration. JOB_ROUTER_ENTRIES is required!
+# Specify additional HTCondor-CE configuration
 # HTCondorCeConfig: |+
-#   JOB_ROUTER_ENTRIES @=jre
-#   [
-#     GridResource = "batch <REMOTE BATCH> <REMOTE USER>@<REMOTE HOST>";
-#     Requirements = (Owner == "<REMOTE USER>");
-#   ]
-#   [
-#   ...
-#   @jre
 
 # Options to allow override of the bosco directory from arbitrary git repos
 # Bosco override dirs are expected in the following location in the git repo:
@@ -73,20 +64,20 @@ HTTPLogger:
 # Default VO-user mappings for OSG Hosted CEs
 # Change these contents for legacy OSG Hosted CEs or non-OSG Hosted CEs
 VomsmapOverride: |+
-  "/osg/Role=NULL/Capability=NULL" osg01
-  "/GLOW/Role=htpc/Capability=NULL" osg02
-  "/hcc/Role=NULL/Capability=NULL" osg03
-  "/cms/*" osg04
-  "/fermilab/*" osg05
-  "/osg/ligo/Role=NULL/Capability=NULL" osg07
-  "/virgo/ligo/Role=NULL/Capability=NULL" osg07
-  "/sdcc/Role=NULL/Capability=NULL" osg08
-  "/sphenix/Role=NULL/Capability=NULL" osg08
-  "/atlas/*" osg09
-  "/Gluex/Role=NULL/Capability=NULL" osg10
-  "/dune/Role=pilot/Capability=NULL" osg11
-  "/icecube/Role=pilot/Capability=NULL" osg12
-  "/xenon.biggrid.nl/Role=NULL/Capability=NULL" osg13
+   "/osg/Role=NULL/Capability=NULL" osg01
+   "/GLOW/Role=htpc/Capability=NULL" osg02
+   "/hcc/Role=NULL/Capability=NULL" osg03
+   "/cms/*" osg04
+   "/fermilab/*" osg05
+   "/osg/ligo/Role=NULL/Capability=NULL" osg07
+   "/virgo/ligo/Role=NULL/Capability=NULL" osg07
+   "/sdcc/Role=NULL/Capability=NULL" osg08
+   "/sphenix/Role=NULL/Capability=NULL" osg08
+   "/atlas/*" osg09
+   "/Gluex/Role=NULL/Capability=NULL" osg10
+   "/dune/Role=pilot/Capability=NULL" osg11
+   "/icecube/Role=pilot/Capability=NULL" osg12
+   "/xenon.biggrid.nl/Role=NULL/Capability=NULL" osg13
 
 # If you wish to allow yourself to submit to this CE with your personal grid
 # proxy, you can put that in below. This will get directly mapped into

--- a/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -3,7 +3,6 @@ Instance: ""
 # Site information that should match the CE Topology registration
 Topology:
   Resource: RESOURCE_NAME
-  ResourceGroup: RESOURCE_GROUP
   Sponsor: osg:100
   Contact: RESOURCE_CONTACT
   ContactEmail: support@example.edu


### PR DESCRIPTION
https://opensciencegrid.atlassian.net/browse/SOFTWARE-3960

This is a major refactor of the Hosted CE chart, including:

- The job router doesn't require any additional configuration unless the operator needs to add custom routes, and even then it's simpler to do because the `GridResource` line is set automatically
- Using default `osg-configure` values wherever possible
- VO and grid map files are now lists
- Other various value renaming and restructuring

This PR still needs a chart version update to 3.0.0 and README updates so I'm submitting this as a WIP PR. Also FYI @jdost321 and @mmascher
