### PR TITLE
Restore resource group

### DIFF
--- a/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.2.1"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.0.1
+version: 3.0.2

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -17,6 +17,7 @@ data:
     {{ end }}
     host_name = localhost
     resource = {{ .Values.Topology.Resource }}
+    resource_group = {{ .Values.Topology.ResourceGroup }}
     sponsor = {{ .Values.Topology.Sponsor }}
     contact = {{ .Values.Topology.Contact }}
     email = {{ .Values.Topology.ContactEmail }}

--- a/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -3,6 +3,7 @@ Instance: ""
 # Site information that should match the CE Topology registration
 Topology:
   Resource: RESOURCE_NAME
+  ResourceGroup: RESOURCE_GROUP
   Sponsor: osg:100
   Contact: RESOURCE_CONTACT
   ContactEmail: support@example.edu


### PR DESCRIPTION
https://opensciencegrid.atlassian.net/browse/SOFTWARE-4107

The current container doesn't have a version of `osg-configure` that requires this again but extra values in the `.ini` are ignored and whenever we release the fixed `osg-configure` the app will readily handle it properly.