### PR TITLE
updated the Globus node selector

### DIFF
--- a/stable/globus-connect-v4/globus-connect-v4/Chart.yaml
+++ b/stable/globus-connect-v4/globus-connect-v4/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.0.59"
 description: Globus Connect data transfer service
 name: globus-connect-v4
-version: 0.6.5
+version: 0.6.6

--- a/stable/globus-connect-v4/globus-connect-v4/templates/deployment.yaml
+++ b/stable/globus-connect-v4/globus-connect-v4/templates/deployment.yaml
@@ -84,7 +84,7 @@ spec:
         - name: pvc-volume
           mountPath: {{ .Values.ExternalPath }}
         {{ end }}
-      {{ if .Values.UseNodeSelector }}
+      {{ if .Values.NodeSelector }}
       nodeSelector:
-        globus: "true"
+        {{ .Values.NodeSelector }}: "true"
       {{ end }}

--- a/stable/globus-connect-v4/globus-connect-v4/values.yaml
+++ b/stable/globus-connect-v4/globus-connect-v4/values.yaml
@@ -46,8 +46,9 @@ ExternalPath: /export
 InternalPath: /mnt
 # The name of a PersistentVolumeClaim which should be mounted as backing storage.
 PVCName: 
-# If set, use a nodeSelector (`globus=true`) to run only on a matching nodes. 
+# If set, use a nodeSelector to run only on a matching nodes. 
 # This is useful when only certain nodes on the cluster mount the appropriate 
 # backing filesystem. It may be desirable to turn this off when using a PVC as
 # backing storage, since this tends not to tie to a specific node. 
-UseNodeSelector: true
+# e.g., "NodeSelector: globus" will match nodes with "globus=true"
+# NodeSelector: globus


### PR DESCRIPTION
The selector's key is now the value of the "NodeSelector:" in the values file. This let's us run multiple Globus endpoints rather than having only one Globus endpoint per cluster