### PR TITLE
Fix path to look for the batch_gahp/blahp (SOFTWARE-4095)

### DIFF
--- a/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.2.1"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.1.1
+version: 3.1.2

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -66,11 +66,12 @@ data:
     # HACK: The job router doesn't recognize grid universe routes (the default) without
     # a "GridResource" attribute and the Gridmanager doesn't evaluate GridResource expressions.
     # So we set a dummy "GridResource" attribute and use "eval_set_GridResource"  to force the
+    # JobRouter to respect our will
     JOB_ROUTER_DEFAULTS @=jrd
     $(JOB_ROUTER_DEFAULTS)
     [
     GridResource = "intentionally left blank";
-    eval_set_GridResource = strcat("batch ", "{{ .Values.RemoteCluster.Batch }} ", Owner, "@", "{{ .Values.RemoteCluster.LoginHost }}", " --rgahp-glite ", {{ .Values.RemoteCluster.BoscoDir | default "bosco" | quote}});
+    eval_set_GridResource = strcat("batch ", "{{ .Values.RemoteCluster.Batch }} ", Owner, "@", "{{ .Values.RemoteCluster.LoginHost }}", " --rgahp-glite ", "{{ .Values.RemoteCluster.BoscoDir | default "bosco"}}/glite");
     ]
     @jrd
 


### PR DESCRIPTION
OSG Ops ran into issues when testing new deployments:

```
  1.0   osg             7/24 08:13 Failed to start GAHP: Agent pid 1953\n/bin/bash: bosco/bin/batch_gahp: No such file or directory\nAgent pid 1953 killed\n
```

The actual path (by default) is `bosco/glite/bin/batch_gahp` so this should fix it. 