### PR TITLE
Globus multi dn

### DIFF
--- a/stable/globus-connect-v4/images/globus-connect-v4/supervisord_startup.sh
+++ b/stable/globus-connect-v4/images/globus-connect-v4/supervisord_startup.sh
@@ -23,7 +23,7 @@ if [[ $? -eq 0 ]]; then
 		echo "shell is: " $shell
         echo "X509 DN(s) are: " $dns
 
-        if [[ $dn == "" ]]; then
+        if [[ $dns == "" ]]; then
 			echo "No X509 DN found. Assuming password/MyProxy authentication"
 		    if [[ $pass == "" ]]; then
 				echo "Password for user $user seems to be empty.. cowardly skipping over this user"


### PR DESCRIPTION
This feature allows a user to specify multiple users for the same DN. This is useful for shared accounts and so on.

Here's a self-contained test of the proposed functionality:

```bash
while read -r user pass uid gid comment home shell dns; do
    echo "username is: " $user
    echo "password is: xxxxxxx"  # we dont watn to print out the password, actually
    echo "uid is: " $uid
    echo "gid is: " $gid
    echo "comment is: " $comment
    echo "home is: " $home
    echo "shell is: " $shell
    echo "X509 DN(s) are: " $dns

    if [[ $dns == "" ]]; then
        echo "No X509 DN found. Assuming password/MyProxy authentication"
        if [[ $pass == "" ]]; then
            echo "Password for user $user seems to be empty.. cowardly skipping over this user"
            continue
        else
            echo useradd $user -d $home -u $uid -s $shell -p $pass
        fi
    else
        echo "Adding user $user"
        echo useradd $user -d $home -u $uid -s $shell
        echo "Adding DN(s) to the gridmap file..."
        for dn in $dns; do
                        echo "\"$dn\" $user" | tee -a grid-mapfile
        done
            fi
    done < passwd-sample
```

For the input file:
```
usatlas1:x:21001:21001:US ATLAS Production:/home/usatlas1:/bin/sh:/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=lbryant/CN=738076/CN=Lincoln Bryant:/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=chroot/CN=123456/CN=Charlie Root
```

I get this output:
```

username is:  usatlas1
password is: xxxxxxx
uid is:  21001
gid is:  21001
comment is:  US ATLAS Production
home is:  /home/usatlas1
shell is:  /bin/sh
X509 DN(s) are:  /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=lbryant/CN=738076/CN=Lincoln Bryant /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=chroot/CN=123456/CN=Charlie Root
Adding user usatlas1
useradd usatlas1 -d /home/usatlas1 -u 21001 -s /bin/sh
Adding DN(s) to the gridmap file...
"/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=lbryant/CN=738076/CN=Lincoln Bryant" usatlas1
"/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=chroot/CN=123456/CN=Charlie Root" usatlas1
```