### PR TITLE
allow users to open additional ports in the service object

### DIFF
--- a/incubator/jupyter-notebook/jupyter-notebook/Chart.yaml
+++ b/incubator/jupyter-notebook/jupyter-notebook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 name: "jupyter-notebook"
-version: 0.3.5
+version: 0.3.6
 appVersion: 2.1.3
 description: "A Jupyter Notebook with a condor-submit setup"
 type: application

--- a/incubator/jupyter-notebook/jupyter-notebook/templates/service.yaml
+++ b/incubator/jupyter-notebook/jupyter-notebook/templates/service.yaml
@@ -30,3 +30,9 @@ spec:
     nodePort: {{ .Values.CondorConfig.ExternalCondorPort }}
     protocol: TCP
   {{ end }}
+  {{ if Values.Network.ExtraPort }} 
+  - name: extra-port
+    port: {{ .Values.Network.ExtraPort }}
+    nodePort: {{ .Values.Network.ExtraPort }}
+    protocol: TCP
+  {{ end }}

--- a/incubator/jupyter-notebook/jupyter-notebook/templates/service.yaml
+++ b/incubator/jupyter-notebook/jupyter-notebook/templates/service.yaml
@@ -30,7 +30,7 @@ spec:
     nodePort: {{ .Values.CondorConfig.ExternalCondorPort }}
     protocol: TCP
   {{ end }}
-  {{ if .Values.Network.ExtraPort }} 
+  {{ if (eq .Values.Network.Enabled true ) }}
   - name: extra-port
     port: {{ .Values.Network.ExtraPort }}
     nodePort: {{ .Values.Network.ExtraPort }}

--- a/incubator/jupyter-notebook/jupyter-notebook/templates/service.yaml
+++ b/incubator/jupyter-notebook/jupyter-notebook/templates/service.yaml
@@ -30,9 +30,9 @@ spec:
     nodePort: {{ .Values.CondorConfig.ExternalCondorPort }}
     protocol: TCP
   {{ end }}
-  {{ if (eq .Values.Network.Enabled true ) }}
+  {{ if (eq .Values.ExtraPort.Enabled true ) }}
   - name: extra-port
-    port: {{ .Values.Network.ExtraPort }}
-    nodePort: {{ .Values.Network.ExtraPort }}
+    port: {{ .Values.ExtraPort.Port }}
+    nodePort: {{ .Values.ExtraPort.Port }}
     protocol: TCP
   {{ end }}

--- a/incubator/jupyter-notebook/jupyter-notebook/templates/service.yaml
+++ b/incubator/jupyter-notebook/jupyter-notebook/templates/service.yaml
@@ -30,7 +30,7 @@ spec:
     nodePort: {{ .Values.CondorConfig.ExternalCondorPort }}
     protocol: TCP
   {{ end }}
-  {{ if Values.Network.ExtraPort }} 
+  {{ if .Values.Network.ExtraPort }} 
   - name: extra-port
     port: {{ .Values.Network.ExtraPort }}
     nodePort: {{ .Values.Network.ExtraPort }}

--- a/incubator/jupyter-notebook/jupyter-notebook/values.yaml
+++ b/incubator/jupyter-notebook/jupyter-notebook/values.yaml
@@ -79,8 +79,9 @@ SSH:
 
 # Uncomment this section if you have additional middleware that needs to have
 # an open inbound tcp port to function.
-#Network:
-#  ExtraPort: 31000
+Network:
+  Enabled: true
+  ExtraPort: 31000
 
 ### SLATE-START ###
 SLATE:

--- a/incubator/jupyter-notebook/jupyter-notebook/values.yaml
+++ b/incubator/jupyter-notebook/jupyter-notebook/values.yaml
@@ -79,9 +79,9 @@ SSH:
 
 # Uncomment this section if you have additional middleware that needs to have
 # an open inbound tcp port to function.
-Network:
+ExtraPort:
   Enabled: true
-  ExtraPort: 31000
+  Port: 31000
 
 ### SLATE-START ###
 SLATE:

--- a/incubator/jupyter-notebook/jupyter-notebook/values.yaml
+++ b/incubator/jupyter-notebook/jupyter-notebook/values.yaml
@@ -77,6 +77,11 @@ SSH:
   #Do NOT use your SSH private key here. Your public ssh key starts with 'ssh-rsa'
   SSH_Public_Key: 'ssh-rsa AAAAB3N=====SamplePublicSSHKey======vH6Edp6+J81Itt+x8Cy/JrjMhzSjAs5Gt1RiKdMSmhclGz3s+h/KL8f12tjA3Uk0PSPqgRTN2L435/X1Hche7CiT6ZJqpCoxa8J4mbLzYaLeGWnNremJ90Q/udO+IUYvviDsgDeB1msIDWfIylDxMteMZ50WTkPVur+Yl2TG6mxNNdNshzHSxtOM3IB2+Q9ChYRFB59J38Wx1+9/1Mnf53 slate'
 
+# Uncomment this section if you have additional middleware that needs to have
+# an open inbound tcp port to function.
+#Network:
+#  ExtraPort: 31000
+
 ### SLATE-START ###
 SLATE:
   Cluster:

--- a/incubator/jupyter-notebook/jupyter-notebook/values.yaml
+++ b/incubator/jupyter-notebook/jupyter-notebook/values.yaml
@@ -77,10 +77,10 @@ SSH:
   #Do NOT use your SSH private key here. Your public ssh key starts with 'ssh-rsa'
   SSH_Public_Key: 'ssh-rsa AAAAB3N=====SamplePublicSSHKey======vH6Edp6+J81Itt+x8Cy/JrjMhzSjAs5Gt1RiKdMSmhclGz3s+h/KL8f12tjA3Uk0PSPqgRTN2L435/X1Hche7CiT6ZJqpCoxa8J4mbLzYaLeGWnNremJ90Q/udO+IUYvviDsgDeB1msIDWfIylDxMteMZ50WTkPVur+Yl2TG6mxNNdNshzHSxtOM3IB2+Q9ChYRFB59J38Wx1+9/1Mnf53 slate'
 
-# Uncomment this section if you have additional middleware that needs to have
-# an open inbound tcp port to function.
+# Enable this section if you have additional middleware that needs to have an
+# open inbound tcp port to function.
 ExtraPort:
-  Enabled: true
+  Enabled: false
   Port: 31000
 
 ### SLATE-START ###


### PR DESCRIPTION
added extra port functionality so we can expose additional ports for middlewares that need inbound connectivity, e.g. parsl

