### PR TITLE
Allow the admin to specify the SSH BatchMode (SOFTWARE-4239)

### DIFF
--- a/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.2.1"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.1.3
+version: 3.2.0

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -71,7 +71,9 @@ data:
     $(JOB_ROUTER_DEFAULTS)
     [
     GridResource = "intentionally left blank";
-    eval_set_GridResource = strcat("batch ", "{{ .Values.RemoteCluster.Batch }} ", Owner, "@", "{{ .Values.RemoteCluster.LoginHost }}", " --rgahp-glite ", "~/{{ .Values.RemoteCluster.BoscoDir | default "~/bosco"}}/glite");
+    eval_set_GridResource = strcat("batch ", "{{ .Values.RemoteCluster.Batch }} ",
+                                   Owner, "@", "{{ .Values.RemoteCluster.LoginHost }} ",
+                                   "--rgahp-glite ", "~/{{ .Values.RemoteCluster.BoscoDir | default "~/bosco"}}/glite");
     ]
     @jrd
 

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -73,7 +73,11 @@ data:
     GridResource = "intentionally left blank";
     eval_set_GridResource = strcat("batch ", "{{ .Values.RemoteCluster.Batch }} ",
                                    Owner, "@", "{{ .Values.RemoteCluster.LoginHost }} ",
-                                   "--rgahp-glite ", "~/{{ .Values.RemoteCluster.BoscoDir | default "~/bosco"}}/glite");
+                                   "--rgahp-glite ", "~/{{ .Values.RemoteCluster.BoscoDir | default "~/bosco"}}/glite"
+                                   {{ if not .Values.RemoteCluster.SSHBatchMode }}
+                                   , " --rgahp-nobatchmode"
+                                   {{ end }}
+                                   );
     ]
     @jrd
 

--- a/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -32,6 +32,9 @@ RemoteCluster:
   WorkerNodeTemp: /tmp
   # <IP OR FQDN>:<PORT> for the site's local squid server, or 'null' if no site Squid
   Squid: null
+  # Control the value of the SSH BatchMode option used by the CE for
+  # communication with the remote cluster
+  SSHBatchMode: True
 
 Networking:
   ServiceType: "LoadBalancer"


### PR DESCRIPTION
To make use of:

```
RemoteCluster:
    SSHBatchMode: False
```

https://github.com/opensciencegrid/docker-hosted-ce/pull/70 needs to be merged and users must pick up the relevant container.