### PR TITLE
Exclude any ":<PORT>" designations from the SSH command

### DIFF
--- a/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.2.1"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.2.0
+version: 3.2.1

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -72,7 +72,7 @@ data:
     [
     GridResource = "intentionally left blank";
     eval_set_GridResource = strcat("batch ", "{{ .Values.RemoteCluster.Batch }} ",
-                                   Owner, "@", "{{ .Values.RemoteCluster.LoginHost }} ",
+                                   Owner, "@", "{{ regexReplaceAllLiteral ":[0-9]*$" .Values.RemoteCluster.LoginHost "" }} ",
                                    "--rgahp-glite ", "~/{{ .Values.RemoteCluster.BoscoDir | default "~/bosco"}}/glite"
                                    {{ if not .Values.RemoteCluster.SSHBatchMode }}
                                    , " --rgahp-nobatchmode"


### PR DESCRIPTION
The GridResource line passes information off to the 'remote_gahp'
script, which doesn't understand the <HOSTNAME>:<PORT> designation.

The Hosted CE containers pre-populate SSH config to specify the
appropriate port for the remote login host so we don't need to retain
the port information.

Fixes/Closes #336 