### PR TITLE
Add external-dns annotations to osg-hosted-ce stable chart

### DIFF
--- a/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.4.1"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.3.0
+version: 3.3.1

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/service.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/service.yaml
@@ -8,6 +8,8 @@ metadata:
     chart: {{ template "osg-hosted-ce.chart" . }}
     release: {{ .Release.Name }}
     instance: {{ .Values.Instance }}
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.Networking.Hostname }} 
 spec:
   type: LoadBalancer
   externalTrafficPolicy: "Local"


### PR DESCRIPTION
Adds hostname to an annotation for the Chart's service object.

```
metadata:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: {{ .Values.Networking.Hostname }} 
```

Requested by @bbockhelm in https://github.com/slateci/slate-catalog/issues/342 

Closes #342 