### PR TITLE
Reinstate single host cert/key secret (SOFTWARE-4299)

### DIFF
--- a/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.4.1"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.3.1
+version: 3.4.0

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
           path: hostkey.pem
           mode: 256
       {{ else }}
-      {{ if .Values.HostCredentials.HostCertSecret }}
+      {{ if and .Values.HostCredentials.HostCertSecret .Values.HostCredentials.HostKeySecret }}
       - name: osg-hosted-ce-hostcert-volume
         secret:
           secretName: {{ .Values.HostCredentials.HostCertSecret }}
@@ -153,7 +153,7 @@ spec:
           mountPath: /etc/grid-security/hostkey.pem
           subPath: hostkey.pem
         {{ else }}
-        {{ if .Values.HostCredentials.HostCertSecret }}
+        {{ if and .Values.HostCredentials.HostCertSecret .Values.HostCredentials.HostKeySecret }}
         - name: osg-hosted-ce-hostcert-volume
           mountPath: /etc/grid-security/hostcert.pem
           subPath: hostcert.pem

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -45,6 +45,17 @@ spec:
           - key: bosco.key
             path: bosco.key
             mode: 256
+      {{ if .Values.HostCredentials.HostCertKeySecret }}
+      - name: osg-hosted-ce-hostcertkey-volume
+        secret: {{ .Values.HostCredentials.HostCertKeySecret }}
+        items:
+        - key: tls.crt
+          path: hostcert.pem
+          mode: 256
+        - key: tls.key
+          path: hostkey.pem
+          mode: 256
+      {{ else }}
       {{ if .Values.HostCredentials.HostCertSecret }}
       - name: osg-hosted-ce-hostcert-volume
         secret:
@@ -53,7 +64,7 @@ spec:
             - key: host.cert
               path: hostcert.pem
               mode: 256
-      {{end}}
+      {{ end }}
       {{ if .Values.HostCredentials.HostKeySecret }}
       - name: osg-hosted-ce-hostkey-volume
         secret:
@@ -62,7 +73,8 @@ spec:
             - key: host.key
               path: hostkey.pem
               mode: 256
-      {{end}}
+      {{ end }}
+      {{ end }}
       {{ if .Values.BoscoOverrides.Enabled }}
       {{ if .Values.BoscoOverrides.GitKeySecret }}
       - name: osg-hosted-ce-{{ .Values.Instance }}-gitkey
@@ -133,6 +145,14 @@ spec:
         - name: osg-hosted-ce-{{ .Values.Instance }}-htcondor-ce-configuration
           mountPath: /etc/condor-ce/config.d/99-instance.conf
           subPath: 99-instance.conf
+        {{ if .Values.HostCredentials.HostCertKeySecret }}
+        - name: osg-hosted-ce-hostcertkey-volume
+          mountPath: /etc/grid-security/hostcert.pem
+          subPath: hostcert.pem
+        - name: osg-hosted-ce-hostcertkey-volume
+          mountPath: /etc/grid-security/hostkey.pem
+          subPath: hostkey.pem
+        {{ else }}
         {{ if .Values.HostCredentials.HostCertSecret }}
         - name: osg-hosted-ce-hostcert-volume
           mountPath: /etc/grid-security/hostcert.pem
@@ -142,6 +162,7 @@ spec:
         - name: osg-hosted-ce-hostkey-volume
           mountPath: /etc/grid-security/hostkey.pem
           subPath: hostkey.pem
+        {{ end }}
         {{ end }}
         {{ if .Values.HTTPLogger.Enabled }}
         - name: log-volume

--- a/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -120,6 +120,10 @@ HTTPLogger:
   # Secret: my-secret
 
 HostCredentials:
+  # Name of the secret containing a host key and certificate in
+  # "tls.key" and "tls.crt", respectively. If defined, values of
+  # HostCertSecret and HostKeySecret are ignored.
+  HostCertKeySecret: null
   # Use a pre-existing host key to request a new Let's Encrypt
   # certificate If HostCertSecret is also specified, the Let's Encrypt
   # request is skipped.  Secret must contain a "host.key" key


### PR DESCRIPTION
To support handling of Let's Encrypt certs through
cert-manager (https://cert-manager.io/)