### PR TITLE
Open Science CE: use htcondor-ce:stable (SOFTWARE-4300)

### DIFF
--- a/incubator/open-science-ce/open-science-ce/Chart.yaml
+++ b/incubator/open-science-ce/open-science-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.2.1"
 description: An OSG Submit Host that accepts remote job submission through HTCondor-CE
 name: open-science-ce
-version: 0.1.17
+version: 0.1.18

--- a/incubator/open-science-ce/open-science-ce/templates/deployment.yaml
+++ b/incubator/open-science-ce/open-science-ce/templates/deployment.yaml
@@ -101,7 +101,7 @@ spec:
           mountPath: /var/lib/condor-ce/spool
       {{ if .Values.HTTPLogger.Enabled }}
       - name: logging-sidecar-init
-        image: opensciencegrid/htcondor-ce:fresh
+        image: opensciencegrid/htcondor-ce:stable
         imagePullPolicy: Always
         command: ['/bin/chown','condor:condor','/var/log/condor-ce']
         volumeMounts:
@@ -143,7 +143,7 @@ spec:
       {{ end }}
 
       - name: open-science-ce
-        image: opensciencegrid/htcondor-ce:fresh
+        image: opensciencegrid/htcondor-ce:stable
         imagePullPolicy: IfNotPresent
 
         volumeMounts:


### PR DESCRIPTION
We're going to be doing some work to base the Hosted CE container off of the HTCondor-CE container so `fresh` may be dangerous for a bit :)