### PR TITLE
Improve documentation for osg-hosted-ce stable chart

### DIFF
--- a/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.4.1"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.4.2
+version: 3.4.4

--- a/stable/osg-hosted-ce/osg-hosted-ce/README.md
+++ b/stable/osg-hosted-ce/osg-hosted-ce/README.md
@@ -117,11 +117,24 @@ Set `Location: null` to disable.
 
 The HostedCE application requires both forward and reverse DNS resolution for its publicly routable IP. Most SLATE clusters come pre-configured with a handful of "LoadBalancer" IP addresses that can be allocated automatically to different applications. You must set-up the DNS records for this address so you will need to request a specific address from the pool.
 
-If you do not know which addresses are available to your cluster, set `RequestIP: null` and deploy the application. Use `slate instance info <INSTANCE ID>` to see which IP address the application recieves, then set that IP in your config and redeploy. 
+If you do not know which addresses are available to your cluster, set `RequestIP: null` and deploy the application. Use `slate instance info <INSTANCE ID>` to see which IP address the application recieves, then set that IP in your config and redeploy.
+
+The default ServiceType is `LoadBalancer` and that value should be used with production CEs.
 
     Networking:
+      ServiceType: "LoadBalancer"
       Hostname: "<YOUR FQDN>"
       RequestIP: <IP ADDRESS>
+      
+*It is possible to run the CE in HostNetworking mode. This allows the container to use the host machine's network directly, and removes a lot of the isolation a container normally has from the host system.*
+
+To enable HostNetworking set
+
+	Networking:
+      	  ServiceType: "HostNetwork"
+          Hostname: "<FQDN OF YOUR KUBERNETES NODE>"
+          RequestIP: <IP ADDRESS OF YOUR KUBERNETES NODE>
+	  
 
 ### VoRemoteUserMapping Section
 
@@ -307,6 +320,7 @@ RemoteCluster:
   Location: squid.example.com:31192
 
 Networking:
+  ServiceType: "LoadBalancer"
   Hostname: "hosted-ce.example.com"
   RequestIP: 0.0.0.0
 

--- a/stable/osg-hosted-ce/osg-hosted-ce/README.md
+++ b/stable/osg-hosted-ce/osg-hosted-ce/README.md
@@ -131,7 +131,7 @@ The default ServiceType is `LoadBalancer` and that value should be used with pro
 To enable HostNetworking set
 
 	Networking:
-      	  ServiceType: "HostNetwork"
+      	   ServiceType: "HostNetwork"
           Hostname: "<FQDN OF YOUR KUBERNETES NODE>"
           RequestIP: <IP ADDRESS OF YOUR KUBERNETES NODE>
 	  

--- a/stable/osg-hosted-ce/osg-hosted-ce/README.md
+++ b/stable/osg-hosted-ce/osg-hosted-ce/README.md
@@ -220,6 +220,13 @@ This allows you to turn toggle HTTP logging side car. When it is enabled, it wil
 
 You may provide a SLATE secret with an `HTPASSWD` key containing password instead of having the container randomly
 generate a password.
+
+**TIP** You can create a SLATE secret containing a predefined password for the logger using a command like this:
+
+```
+slate secret create <name-of-your-secret> --group <your-group> --cluster <your-cluster> --from-literal HTPASSWD=<your-desired-password>
+```
+
 To disable this, comment out the `Secret` line (default).
 
 	HTTPLogger:

--- a/stable/osg-hosted-ce/osg-hosted-ce/README.md
+++ b/stable/osg-hosted-ce/osg-hosted-ce/README.md
@@ -135,6 +135,8 @@ To enable HostNetworking set
           Hostname: "<FQDN OF YOUR KUBERNETES NODE>"
           RequestIP: <IP ADDRESS OF YOUR KUBERNETES NODE>
 	  
+*HostNetwork should be avoided for Production CEs*
+	  
 
 ### VoRemoteUserMapping Section
 


### PR DESCRIPTION
1) Updates documentation to show an example of secret creation for the Logger password.

2) Updates documentation to reflect the changes to networking. Documents new `ServiceType` values field, and discusses HostNetworking.

Closes #238 and #338 

