### PR TITLE
Dynamic cache and meta directory creation in Helm template

### DIFF
--- a/incubator/cms-xcache/cms-xcache/Chart.yaml
+++ b/incubator/cms-xcache/cms-xcache/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cms-xcache
 # Chart version
-version: 0.1.4
+version: 0.1.5
 description: XCache is a xrootd based caching service for k8s
 # Version of application packaged for installation
 appVersion: "4.11"

--- a/incubator/cms-xcache/cms-xcache/templates/configmap.yaml
+++ b/incubator/cms-xcache/cms-xcache/templates/configmap.yaml
@@ -9,7 +9,9 @@ metadata:
     instance: {{ .Values.Instance | quote }}
 data: 
   cache-disks.config: |+
-{{ .Values.CacheDisks | indent 4 }}
+    {{- range $index, $path := .Values.XCacheConfig.CacheDirectories }} 
+    oss.space {{ .path }} {{ .type }}
+    {{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/incubator/cms-xcache/cms-xcache/templates/deployment.yaml
+++ b/incubator/cms-xcache/cms-xcache/templates/deployment.yaml
@@ -53,59 +53,16 @@ spec:
             mode: 256 
           - key: usercert
             path: usercert.pem
-      - name: data2
+      {{- range $nindex, $dir := .Values.XCacheConfig.CacheDirectories }}
+      - name: {{ .type}}_{{ $nindex }}
         hostPath:
-          path: /data2
+          path: {{ .path }}
           type: Directory
-      - name: data3
-        hostPath:
-          path: /data3
-          type: Directory
-      - name: data4
-        hostPath:
-          path: /data4
-          type: Directory
-      - name: data5
-        hostPath:
-          path: /data5
-          type: Directory
-      - name: data6
-        hostPath:
-          path: /data6
-          type: Directory
-      - name: data7
-        hostPath:
-          path: /data7
-          type: Directory
-      - name: data8
-        hostPath:
-          path: /data8
-          type: Directory
-      - name: data9
-        hostPath:
-          path: /data9
-          type: Directory
-      - name: data10
-        hostPath:
-          path: /data10
-          type: Directory
-      - name: data11
-        hostPath:
-          path: /data11
-          type: Directory
-      - name: data12
-        hostPath:
-          path: /data12
-          type: Directory
+      {{- end }}
       - name: localroot
         hostPath:
-          path: /xcache-root
+          path: {{ .Values.LocalRoot }}
           type: Directory
-      - name: localmeta
-        hostPath:
-          path: /xcache-meta
-          type: Directory
-    
       containers:
         - name: cms-xcache
           image: "opensciencegrid/cms-xcache:fresh"
@@ -156,27 +113,9 @@ spec:
           - name: x509-certs-volume
             mountPath: "/etc/grid-certs/"
             readOnly: true
-          - mountPath: /data2
-            name: data2
-          - mountPath: /xcache-root
-            name: localroot
-          - mountPath: /xcache-meta
-            name: localmeta
-          - mountPath: /data3
-            name: data3
-          - mountPath: /data4
-            name: data4
-          - mountPath: /data5
-            name: data5
-          - mountPath: /data6
-            name: data6
-          - mountPath: /data7
-            name: data7
-          - mountPath: /data8
-            name: data8
-          - mountPath: /data9
-            name: data9
-          - mountPath: /data10
-            name: data10
-          - mountPath: /data11
-            name: data11
+          - name: localroot
+            mountPath: {{ .Values.LocalRoot }}
+          {{- range $nindex, $dir := .Values.XCacheConfig.CacheDirectories }}
+          - name: {{ .type }}-{{ $nindex }}
+            mountPath: {{ .path }}
+          {{- end }}

--- a/incubator/cms-xcache/cms-xcache/values.yaml
+++ b/incubator/cms-xcache/cms-xcache/values.yaml
@@ -38,10 +38,13 @@ XCacheConfig:
   CertSecret: xcache-cert-secret
   # Disable OSG monitoring and reporting
   DisableOSGMonitoring: true
-  
-CacheDisks: |+
-  oss.space data /data3/xcache
-  oss.space data /data4/xcache
-  oss.space data /data5/xcache
-  oss.space data /data6/xcache
-  
+  LocalRoot: /xrootd-root
+  CacheDirectories:
+    - path: /data1/xcache
+      type: data
+    - path: /data2/xcache
+      type: data
+    - path: /data3/xcache
+      type: data
+    - path: /meta
+      type: meta


### PR DESCRIPTION
Users can now specify the cache directories which get unrolled into the config