### PR TITLE
Change disk mount locations

### DIFF
--- a/incubator/cms-xcache/cms-xcache/Chart.yaml
+++ b/incubator/cms-xcache/cms-xcache/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cms-xcache
 # Chart version
-version: 0.1.5
+version: 0.1.6
 description: XCache is a xrootd based caching service for k8s
 # Version of application packaged for installation
 appVersion: "4.11"

--- a/incubator/cms-xcache/cms-xcache/templates/configmap.yaml
+++ b/incubator/cms-xcache/cms-xcache/templates/configmap.yaml
@@ -1,21 +1,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "cms-xcache.fullname" . }}-disks
-  labels:
-    app: {{ template "cms-xcache.name" . }}
-    chart: {{ template "cms-xcache.chart" . }}
-    release: {{ .Release.Name }}
-    instance: {{ .Values.Instance | quote }}
-data: 
-  cache-disks.config: |+
-    {{- range $index, $path := .Values.XCacheConfig.CacheDirectories }} 
-    oss.space {{ .path }} {{ .type }}
-    {{- end }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
   name: {{ template "cms-xcache.fullname" . }}-clustered
   labels:
     app: {{ template "cms-xcache.name" . }}
@@ -23,11 +8,11 @@ metadata:
     release: {{ .Release.Name }}
     instance: {{ .Values.Instance | quote }}
 data: 
-  xrootd-clustered.cfg: |+
+  xrootd-clustered.cfg: |-
     # Monitoring configuration. The latest recommendations are also kept at:
     # https://twiki.cern.ch/twiki/bin/view/Main/XrootdMonitoring
     xrd.report {{ .Values.Monitoring.Collector }} every 60s all sync
-    xrootd.monitor all auth flush io 60s ident 5m mbuff 8k rbuff 4k rnums 3 window 10s dest files io info user redir xrootd.t2.ucsd.edu:9930
+    xrootd.monitor all auth flush io 60s ident 5m mbuff 8k rbuff 4k rnums 3 window 10s dest files io info user redir {{ .Values.Monitoring.Collector }}
     # this is arbitrary as our client will provide origin
     pss.origin = {{ .Values.SiteConfig.Origin }}
     all.sitename {{ .Values.SiteConfig.Name }}

--- a/incubator/cms-xcache/cms-xcache/templates/configmap.yaml
+++ b/incubator/cms-xcache/cms-xcache/templates/configmap.yaml
@@ -11,12 +11,12 @@ data:
   xrootd-clustered.cfg: |+
     # Monitoring configuration. The latest recommendations are also kept at:
     # https://twiki.cern.ch/twiki/bin/view/Main/XrootdMonitoring
-    xrd.report {{ .Values.Monitoring.Collector }} every 60s all sync
-    xrootd.monitor all auth flush io 60s ident 5m mbuff 8k rbuff 4k rnums 3 window 10s dest files io info user redir {{ .Values.Monitoring.Collector }}
+    xrd.report {{ required "A collector is required" .Values.Monitoring.Collector }} every 60s all sync
+    xrootd.monitor all auth flush io 60s ident 5m mbuff 8k rbuff 4k rnums 3 window 10s dest files io info user redir {{ required "A collector is required" .Values.Monitoring.Collector }}
     # this is arbitrary as our client will provide origin
-    pss.origin = {{ .Values.SiteConfig.Origin }}
-    all.sitename {{ .Values.SiteConfig.Name }}
+    pss.origin = {{ required "An origin is required" .Values.SiteConfig.Origin }}
+    all.sitename {{ required "A site name is required" .Values.SiteConfig.Name }}
     # Connect to NDCMS manager
-    set xrdr = {{ .Values.SiteConfig.Manager }}
+    set xrdr = {{ required "A Manager is required" .Values.SiteConfig.Manager }}
     # Tell everyone who the manager is
     all.manager $(xrdr):3121

--- a/incubator/cms-xcache/cms-xcache/templates/configmap.yaml
+++ b/incubator/cms-xcache/cms-xcache/templates/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     instance: {{ .Values.Instance | quote }}
 data: 
-  xrootd-clustered.cfg: |-
+  xrootd-clustered.cfg: |+
     # Monitoring configuration. The latest recommendations are also kept at:
     # https://twiki.cern.ch/twiki/bin/view/Main/XrootdMonitoring
     xrd.report {{ .Values.Monitoring.Collector }} every 60s all sync

--- a/incubator/cms-xcache/cms-xcache/templates/deployment.yaml
+++ b/incubator/cms-xcache/cms-xcache/templates/deployment.yaml
@@ -34,12 +34,9 @@ spec:
         effect: PreferNoSchedule
 
       volumes:
-      - name: cache-disks
+      - name: xrootd-config
         configMap:
-          name: {{ template "cms-xcache.fullname" . }}-disks
-      - name: xrootd-clustered
-        configMap:
-          name: {{ template "cms-xcache.fullname" . }}-clustered
+          name: {{ template "cms-xcache.fullname" . }}-config
       - name: x509-data
         emptyDir:
           medium: Memory
@@ -84,6 +81,8 @@ spec:
             value: "{{ .Values.XCacheConfig.BlockSize }}"
           - name: XC_PREFETCH
             value: "{{ .Values.XCacheConfig.Prefetch }}"
+          - name: XC_ROOTDIR
+            value: "{{ .Values.XCacheConfig.LocalRoot }}"
           - name: WQ_BLOCKS_PER_LOOP
             value: "{{ .Values.XCacheConfig.WQBlocksPerLoop }}"
           - name: WQ_THREADS
@@ -103,10 +102,8 @@ spec:
           ports:
             - containerPort: {{ .Values.Service.Port }}         
           volumeMounts:
-          - name: cache-disks
-            mountPath: /etc/xrootd/cache-disks.config
-          - name: xrootd-clustered
-            mountPath: /etc/xrootd/xrootd-clustered.cfg
+          - name: xrootd-config
+            mountPath: /etc/xrootd/config.d/xrootd-config.cfg
           - name: x509-data
             mountPath: "/etc/proxy/"
             readOnly: true
@@ -117,5 +114,9 @@ spec:
             mountPath: {{ .Values.LocalRoot }}
           {{- range $nindex, $dir := .Values.XCacheConfig.CacheDirectories }}
           - name: {{ .type }}-{{ $nindex }}
-            mountPath: {{ .path }}
+            {{- if eq .type "data" }}
+            mountPath: /xcache/data-{{ $nindex }}
+            {{- else if eq .type "meta" }}
+            mountPath: /xcache/meta-{{ $nindex }}
+            {{- end }}
           {{- end }}

--- a/incubator/cms-xcache/cms-xcache/values.yaml
+++ b/incubator/cms-xcache/cms-xcache/values.yaml
@@ -38,7 +38,7 @@ XCacheConfig:
   CertSecret: xcache-cert-secret
   # Disable OSG monitoring and reporting
   DisableOSGMonitoring: true
-  LocalRoot: /xrootd-root
+  LocalRoot: /xcache/namespace
   CacheDirectories:
     - path: /data1/xcache
       type: data


### PR DESCRIPTION
OSG's XCache chart prescribes the location where disks ought to be mounted. I've changed the chart to reflect that. See the following:
https://github.com/opensciencegrid/docker-xcache/blob/master/xcache/image-config.d/10-single-host-disk.sh#L3-L21

