### PR TITLE
Hosted CE fixup comments; hardcode GridDir

### DIFF
--- a/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.4.1"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.4.6
+version: 3.4.7

--- a/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -25,11 +25,17 @@ RemoteCluster:
   MaxWallTime: 1440
   # Name for the remote bosco installation dir
   BoscoDir: bosco
-  # Absolute path to the local WN client installation
-  # Do not use environment variables!
-  GridDir: /home/osguser/bosco-osg-wn-client
+  # Absolute path to the local WN client installation. Should be one of:
+  # - $HOME/bosco-osg-wn-client
+  # - /cvmfs/oasis.opensciencegrid.org/osg-software/osg-wn-client/current/el7-x86_64/
+  #   (replacing "el7" with the remote OS major version)
+  GridDir: $HOME/bosco-osg-wn-client
   # Worker node scratch space for payload jobs
-  # Do not use environment variables!
+  # 1. For non-HTCondor batch systems, use of environment vars is supported
+  # 2. For HTCondor batch systems, only "$HOME" is accepted. For an
+  #    HTCondor site a directory specified in MOUNT_UNDER_SCRATCH in
+  #    their HTCondor configuration, or ask the Factory to specify
+  #    'work_dir="Condor"' in the appropriate entries
   WorkerNodeTemp: /tmp
   # <IP OR FQDN>:<PORT> for the site's local squid server, or 'null' if no site Squid
   Squid: null


### PR DESCRIPTION
1. `MOUNT_UNDER_SCRATCH`: https://opensciencegrid.org/docs/worker-node/using-wn/#for-site-administrators
1. Prescribed `GridDir` location: https://github.com/opensciencegrid/docker-hosted-ce/pull/88/files#diff-60941ebacfc9cf36b6b796d3cfcf856727c6c9249b9d882c1329e76abdcb270dR94