### PR TITLE
[osg-hosted-ce] [incubator] Add (optional) persistent logging

### DIFF
--- a/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "4.2.1"
+appVersion: "4.4.1"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.1.3
+version: 3.4.7

--- a/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.4.1"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.4.7
+version: 3.5.0

--- a/incubator/osg-hosted-ce/osg-hosted-ce/README.md
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/README.md
@@ -117,11 +117,26 @@ Set `Location: null` to disable.
 
 The HostedCE application requires both forward and reverse DNS resolution for its publicly routable IP. Most SLATE clusters come pre-configured with a handful of "LoadBalancer" IP addresses that can be allocated automatically to different applications. You must set-up the DNS records for this address so you will need to request a specific address from the pool.
 
-If you do not know which addresses are available to your cluster, set `RequestIP: null` and deploy the application. Use `slate instance info <INSTANCE ID>` to see which IP address the application recieves, then set that IP in your config and redeploy. 
+If you do not know which addresses are available to your cluster, set `RequestIP: null` and deploy the application. Use `slate instance info <INSTANCE ID>` to see which IP address the application recieves, then set that IP in your config and redeploy.
+
+The default ServiceType is `LoadBalancer` and that value should be used with production CEs.
 
     Networking:
+      ServiceType: "LoadBalancer"
       Hostname: "<YOUR FQDN>"
       RequestIP: <IP ADDRESS>
+      
+*It is possible to run the CE in HostNetworking mode. This allows the container to use the host machine's network directly, and removes a lot of the isolation a container normally has from the host system.*
+
+To enable HostNetworking set
+
+	Networking:
+      	   ServiceType: "HostNetwork"
+          Hostname: "<FQDN OF YOUR KUBERNETES NODE>"
+          RequestIP: <IP ADDRESS OF YOUR KUBERNETES NODE>
+	  
+*HostNetwork should be avoided for Production CEs*
+	  
 
 ### VoRemoteUserMapping Section
 
@@ -220,6 +235,13 @@ This allows you to turn toggle HTTP logging side car. When it is enabled, it wil
 
 You may provide a SLATE secret with an `HTPASSWD` key containing password instead of having the container randomly
 generate a password.
+
+**TIP** You can create a SLATE secret containing a predefined password for the logger using a command like this:
+
+```
+slate secret create <name-of-your-secret> --group <your-group> --cluster <your-cluster> --from-literal HTPASSWD=<your-desired-password>
+```
+
 To disable this, comment out the `Secret` line (default).
 
 	HTTPLogger:
@@ -300,6 +322,7 @@ RemoteCluster:
   Location: squid.example.com:31192
 
 Networking:
+  ServiceType: "LoadBalancer"
   Hostname: "hosted-ce.example.com"
   RequestIP: 0.0.0.0
 

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -9,8 +9,11 @@ metadata:
     release: {{ .Release.Name }}
 data:
   99-local.ini: |
+    [Gateway]
+    job_envvar_path=$PATH
+
     [Site Information]
-    {{ if .Values.Developer.Enabled }}
+    {{ if or (.Values.Developer.Enabled) (not .Values.Topology.Production) }}
     group = OSG-ITB
     {{ else }}
     group = OSG
@@ -63,6 +66,9 @@ data:
     TCP_FORWARDING_HOST = {{ .Values.Networking.RequestIP }}
 {{ end }}
 
+    SLATE_HOSTED_CE = True
+    SCHEDD_ATTRS = $(SCHEDD_ATTRS) SLATE_HOSTED_CE
+
     # HACK: The job router doesn't recognize grid universe routes (the default) without
     # a "GridResource" attribute and the Gridmanager doesn't evaluate GridResource expressions.
     # So we set a dummy "GridResource" attribute and use "eval_set_GridResource"  to force the
@@ -71,7 +77,13 @@ data:
     $(JOB_ROUTER_DEFAULTS)
     [
     GridResource = "intentionally left blank";
-    eval_set_GridResource = strcat("batch ", "{{ .Values.RemoteCluster.Batch }} ", Owner, "@", "{{ .Values.RemoteCluster.LoginHost }}", " --rgahp-glite ", "~/{{ .Values.RemoteCluster.BoscoDir | default "~/bosco"}}/glite");
+    eval_set_GridResource = strcat("batch ", "{{ .Values.RemoteCluster.Batch }} ",
+                                   Owner, "@", "{{ regexReplaceAllLiteral ":[0-9]*$" .Values.RemoteCluster.LoginHost "" }} ",
+                                   "--rgahp-glite ", "~/{{ .Values.RemoteCluster.BoscoDir | default "~/bosco"}}/glite"
+                                   {{ if not .Values.RemoteCluster.SSHBatchMode }}
+                                   , " --rgahp-nobatchmode"
+                                   {{ end }}
+                                   );
     ]
     @jrd
 

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -88,8 +88,14 @@ spec:
       {{ end }}
       {{ end }}
       {{ if .Values.HTTPLogger.Enabled }}
+      {{ if .Values.HTTPLogger.Volume }}
+      - name: log-volume
+        persistentVolumeClaim:
+          claimName: {{ .Values.HTTPLogger.Volume }}
+      {{ else }}
       - name: log-volume
         emptyDir: {} 
+      {{ end }}
       - name: osg-hosted-ce-{{ .Values.Instance }}-logger-startup
         configMap:
           name: osg-hosted-ce-{{ .Values.Instance }}-logger-startup

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -45,7 +45,19 @@ spec:
           - key: bosco.key
             path: bosco.key
             mode: 256
-      {{ if .Values.HostCredentials.HostCertSecret }}
+      {{ if .Values.HostCredentials.HostCertKeySecret }}
+      - name: osg-hosted-ce-hostcertkey-volume
+        secret:
+          secretName: {{ .Values.HostCredentials.HostCertKeySecret }}
+          items:
+          - key: tls.crt
+            path: hostcert.pem
+            mode: 256
+          - key: tls.key
+            path: hostkey.pem
+            mode: 256
+      {{ else }}
+      {{ if and .Values.HostCredentials.HostCertSecret .Values.HostCredentials.HostKeySecret }}
       - name: osg-hosted-ce-hostcert-volume
         secret:
           secretName: {{ .Values.HostCredentials.HostCertSecret }}
@@ -53,7 +65,7 @@ spec:
             - key: host.cert
               path: hostcert.pem
               mode: 256
-      {{end}}
+      {{ end }}
       {{ if .Values.HostCredentials.HostKeySecret }}
       - name: osg-hosted-ce-hostkey-volume
         secret:
@@ -62,7 +74,8 @@ spec:
             - key: host.key
               path: hostkey.pem
               mode: 256
-      {{end}}
+      {{ end }}
+      {{ end }}
       {{ if .Values.BoscoOverrides.Enabled }}
       {{ if .Values.BoscoOverrides.GitKeySecret }}
       - name: osg-hosted-ce-{{ .Values.Instance }}-gitkey
@@ -84,7 +97,7 @@ spec:
       {{ if .Values.HTTPLogger.Enabled }}
       initContainers:
       - name: logging-sidecar-init
-        image: brianhlin/hosted-ce:gittrac7788
+        image: opensciencegrid/hosted-ce:{{ .Values.ContainerTags.HostedCE }}
         imagePullPolicy: Always
         command: ['/bin/chown','condor:condor','/var/log/condor-ce']
         volumeMounts:
@@ -121,7 +134,7 @@ spec:
         {{ end }}
       {{ end }}
       - name: osg-hosted-ce
-        image: brianhlin/hosted-ce:gittrac7788
+        image: opensciencegrid/hosted-ce:{{ .Values.ContainerTags.HostedCE }}
         imagePullPolicy: Always
         volumeMounts:
         - name: osg-hosted-ce-{{ .Values.Instance }}-configuration
@@ -133,7 +146,15 @@ spec:
         - name: osg-hosted-ce-{{ .Values.Instance }}-htcondor-ce-configuration
           mountPath: /etc/condor-ce/config.d/99-instance.conf
           subPath: 99-instance.conf
-        {{ if .Values.HostCredentials.HostCertSecret }}
+        {{ if .Values.HostCredentials.HostCertKeySecret }}
+        - name: osg-hosted-ce-hostcertkey-volume
+          mountPath: /etc/grid-security/hostcert.pem
+          subPath: hostcert.pem
+        - name: osg-hosted-ce-hostcertkey-volume
+          mountPath: /etc/grid-security/hostkey.pem
+          subPath: hostkey.pem
+        {{ else }}
+        {{ if and .Values.HostCredentials.HostCertSecret .Values.HostCredentials.HostKeySecret }}
         - name: osg-hosted-ce-hostcert-volume
           mountPath: /etc/grid-security/hostcert.pem
           subPath: hostcert.pem
@@ -142,6 +163,7 @@ spec:
         - name: osg-hosted-ce-hostkey-volume
           mountPath: /etc/grid-security/hostkey.pem
           subPath: hostkey.pem
+        {{ end }}
         {{ end }}
         {{ if .Values.HTTPLogger.Enabled }}
         - name: log-volume
@@ -185,6 +207,12 @@ spec:
         {{ end }}
         - name: CE_CONTACT
           value: {{ .Values.Topology.ContactEmail }}
+        - name: LE_STAGING
+          {{ if .Values.HostCredentials.LetsEncryptStaging }} # https://github.com/helm/helm/issues/2848
+          value: "true"
+          {{ else }}
+          value: "false"
+          {{ end }}
         - name: RESOURCE_NAME
           value: {{ .Values.Topology.Resource }}
         - name: REMOTE_HOST

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/service.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/service.yaml
@@ -8,6 +8,8 @@ metadata:
     chart: {{ template "osg-hosted-ce.chart" . }}
     release: {{ .Release.Name }}
     instance: {{ .Values.Instance }}
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.Networking.Hostname }} 
 spec:
   type: LoadBalancer
   externalTrafficPolicy: "Local"

--- a/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -124,6 +124,10 @@ HTTPLogger:
   # If you want to insert a password instead of using a randomly generated one,
   # point Secret to a K8S/SLATE secret below.
   # Secret: my-secret
+  
+  # If you want to enable persistent logging you can specify an existing SLATE volume
+  # To create a compatable SLATE volume run `slate volume create <volume-name> --accessMode ReadWriteMany --size 1Gi --storageClass local-path`
+  # Volume: my-volume
 
 HostCredentials:
   # Name of the secret containing a host key and certificate in

--- a/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -11,6 +11,7 @@ Topology:
   Country: US
   Latitude: 0.00
   Longitude: 0.00
+  Production: true
 
 RemoteCluster:
   # SSH host
@@ -24,14 +25,23 @@ RemoteCluster:
   MaxWallTime: 1440
   # Name for the remote bosco installation dir
   BoscoDir: bosco
-  # Absolute path to the local WN client installation
-  # Do not use environment variables!
-  GridDir: /home/osguser/bosco-osg-wn-client
+  # Absolute path to the local WN client installation. Should be one of:
+  # - $HOME/bosco-osg-wn-client
+  # - /cvmfs/oasis.opensciencegrid.org/osg-software/osg-wn-client/current/el7-x86_64/
+  #   (replacing "el7" with the remote OS major version)
+  GridDir: $HOME/bosco-osg-wn-client
   # Worker node scratch space for payload jobs
-  # Do not use environment variables!
+  # 1. For non-HTCondor batch systems, use of environment vars is supported
+  # 2. For HTCondor batch systems, only "$HOME" is accepted. For an
+  #    HTCondor site a directory specified in MOUNT_UNDER_SCRATCH in
+  #    their HTCondor configuration, or ask the Factory to specify
+  #    'work_dir="Condor"' in the appropriate entries
   WorkerNodeTemp: /tmp
   # <IP OR FQDN>:<PORT> for the site's local squid server, or 'null' if no site Squid
   Squid: null
+  # Control the value of the SSH BatchMode option used by the CE for
+  # communication with the remote cluster
+  SSHBatchMode: True
 
 Networking:
   ServiceType: "LoadBalancer"
@@ -116,6 +126,10 @@ HTTPLogger:
   # Secret: my-secret
 
 HostCredentials:
+  # Name of the secret containing a host key and certificate in
+  # "tls.key" and "tls.crt", respectively. If defined, values of
+  # HostCertSecret and HostKeySecret are ignored.
+  HostCertKeySecret: null
   # Use a pre-existing host key to request a new Let's Encrypt
   # certificate If HostCertSecret is also specified, the Let's Encrypt
   # request is skipped.  Secret must contain a "host.key" key
@@ -127,6 +141,10 @@ HostCredentials:
   # Secret must contain a "host.cert" containing the encoded host
   # certificate.
   HostCertSecret: null
+  # If set to 'true', use the Let's Encrypt staging server. This is
+  # useful for avoiding Let's Encrypt rate limits when first setting
+  # up a CE. NOT SUITABLE FOR PRODUCTION USE.
+  LetsEncryptStaging: false
 
 # Choose which tag to use for the specified containers
 ContainerTags:


### PR DESCRIPTION
*Requires the latest SLATE API only currently available at api-dev.slateci.io*

Adds optional persistent logging to osg-hosted-ce. This feature uses new SLATE volumes to create a long lived volume for logs that can be shared by instances across restarts and updates.