### PR TITLE
increased ephemeral storage for xcache

### DIFF
--- a/stable/xcache/xcache/templates/deployment.yaml
+++ b/stable/xcache/xcache/templates/deployment.yaml
@@ -88,9 +88,9 @@ spec:
             value: "{{ .Values.Monitoring.GStreamCollector }}"
           resources:
             requests:
-              ephemeral-storage: "5Gi"
-            limits:
               ephemeral-storage: "10Gi"
+            limits:
+              ephemeral-storage: "20Gi"
           livenessProbe:
             tcpSocket:
               port: {{ .Values.Service.Port }}


### PR DESCRIPTION
just an increase in ephemeral storage. xcache logs tend to be big!