### PR TITLE
[Incubator][cms-xcache] Enable Node Selection based on Hostname

### DIFF
--- a/incubator/cms-xcache/cms-xcache/Chart.yaml
+++ b/incubator/cms-xcache/cms-xcache/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cms-xcache
 # Chart version
-version: 0.1.15
+version: 0.2.0
 description: XCache is a xrootd based caching service for k8s
 # Version of application packaged for installation
 appVersion: "4.11"

--- a/incubator/cms-xcache/cms-xcache/Chart.yaml
+++ b/incubator/cms-xcache/cms-xcache/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cms-xcache
 # Chart version
-version: 0.2.0
+version: 0.2.1
 description: XCache is a xrootd based caching service for k8s
 # Version of application packaged for installation
 appVersion: "4.11"

--- a/incubator/cms-xcache/cms-xcache/README.md
+++ b/incubator/cms-xcache/cms-xcache/README.md
@@ -14,17 +14,6 @@ $ slate app install --group <group-name> --cluster <cluster-name> xcache.yaml
 ## Introduction
 XCache is a service that provides caching of data accessed using [xrootd protocol](http://xrootd.org/). It sits in between client and an upstream xrootd servers and can cache/prefetch full files or only blocks already requested. 
 
-To run this chart one needs a k8s cluster with a node labeled: __xcache-capable: "true"__. This node will have at least 10Gbps connection and at least few TB local disk (preferably mounted at __/scratch__).
-  
-XCache nodes should be tainted:
-```
-kubectl taint nodes "xcache nodename" special=true:PreferNoSchedule
-```
-and labeled:
-```
-kubectl label nodes <your-node-name> xcache-capable=true
-```
-
 ## Prerequisites
 
 - PV provisioner support in the underlying infrastructure

--- a/incubator/cms-xcache/cms-xcache/templates/deployment.yaml
+++ b/incubator/cms-xcache/cms-xcache/templates/deployment.yaml
@@ -56,6 +56,8 @@ spec:
         hostPath:
           path: {{ required "LocalRoot is required" .Values.XCacheConfig.LocalRoot }}
           type: Directory
+      nodeSelector: 
+        kubernetes.io/hostname: {{ .Values.NodeName }} 
       containers:
         - name: cms-xcache
           image: "opensciencegrid/cms-xcache:fresh"

--- a/incubator/cms-xcache/cms-xcache/values.yaml
+++ b/incubator/cms-xcache/cms-xcache/values.yaml
@@ -3,6 +3,10 @@
 # Enables unique instances of XCache in one namespace
 Instance: ""
 
+# The node (in your Kubernetes cluster) to schedule this instance on
+# This hostname should match the host certificate provided in your SLATE secret
+Node: k8s-1.example.edu
+
 Service:
   # Port that the service will utilize.
   Port: 1094

--- a/incubator/cms-xcache/cms-xcache/values.yaml
+++ b/incubator/cms-xcache/cms-xcache/values.yaml
@@ -5,7 +5,8 @@ Instance: ""
 
 # The node (in your Kubernetes cluster) to schedule this instance on
 # This hostname should match the host certificate provided in your SLATE secret
-Node: k8s-1.example.edu
+# Should match the FQDN of the node you want this instance to land on
+NodeName: k8s-1.example.edu
 
 Service:
   # Port that the service will utilize.


### PR DESCRIPTION
-Adds new Value called `NodeName`. Allows the user deploying the chart to specify the hostname of the Kubernetes node that is desired for scheduling the cache.

-Chart 0.2.0