### PR TITLE
Add debug statement to Jenkinsfile pipeline script (printenv)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,7 @@ pipeline{
 					sh 'cmake3 ..'
 					sh 'make'
 					script{
+						sh 'printenv'
 						if(env.BRANCH_NAME == 'master'){
 							sh 'make publish'
 						}


### PR DESCRIPTION
I want to see the contents of the environment when Jenkins pipeline fails to publish catalog builds.