### PR TITLE
[incubator][cms-xcache] Remove old toleration and node selection (inherited from Atlas)

### DIFF
--- a/incubator/cms-xcache/cms-xcache/Chart.yaml
+++ b/incubator/cms-xcache/cms-xcache/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cms-xcache
 # Chart version
-version: 0.2.1
+version: 0.2.2
 description: XCache is a xrootd based caching service for k8s
 # Version of application packaged for installation
 appVersion: "4.11"

--- a/incubator/cms-xcache/cms-xcache/templates/deployment.yaml
+++ b/incubator/cms-xcache/cms-xcache/templates/deployment.yaml
@@ -24,15 +24,6 @@ spec:
         release: {{ .Release.Name }}
         instance: {{ .Values.Instance | quote }}
     spec:
-
-      nodeSelector:
-        xcache-capable: "true"
-      
-      tolerations:
-      - key: "special"
-        operator: "Exists"
-        effect: PreferNoSchedule
-
       volumes:
       - name: xrootd-config
         configMap:


### PR DESCRIPTION
Doing this with hostnames instead. Removing:

```
      nodeSelector:
        xcache-capable: "true"

      tolerations:
      - key: "special"
        operator: "Exists"
        effect: PreferNoSchedule
```