### PR TITLE
Fix selector

### DIFF
--- a/stable/gridftp/gridftp/Chart.yaml
+++ b/stable/gridftp/gridftp/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "6.0"
 description: Globus GridFTP data management system 
 name: gridftp
-version: 0.4.5
+version: 0.4.6

--- a/stable/gridftp/gridftp/templates/deployment.yaml
+++ b/stable/gridftp/gridftp/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
             - name: pvc-volume
               mountPath: {{ .Values.GridFTPConfig.ExternalPath }}
             {{ end }}
-      {{ if .Values.GridFTPConfig.UseNodeSelector }}
+      {{ if .Values.NodeName }}
       nodeSelector:
-        gridftp: "true"
+        kubernetes.io/hostname: {{ .Values.NodeName }}
       {{ end }}

--- a/stable/gridftp/gridftp/values.yaml
+++ b/stable/gridftp/gridftp/values.yaml
@@ -20,8 +20,9 @@ GridFTPConfig:
   InternalPath: /mnt
   # The name of a PersistentVolumeClaim which should be mounted as backing storage.
   PVCName: 
-  # If set, use a nodeSelector (`gridftp=true`) to run only on a matching nodes. 
-  # This is useful when only certain nodes on the cluster mount the appropriate 
-  # backing filesystem. It may be desirable to turn this off when using a PVC as
-  # backing storage, since this tends not to tie to a specific node. 
-  UseNodeSelector: false
+
+# If set, only run this pod on the matching node name.
+# This is useful when only certain nodes on the cluster mount the appropriate 
+# backing filesystem. It may be desirable to turn this off when using a PVC as
+# backing storage, since this tends not to tie to a specific node. 
+#NodeName: 


### PR DESCRIPTION
This patch changes the GridFTP application to use a hostname-based node selector, much like CMS XCache. 