### PR TITLE
[incubator][cms-xcache] Add Ability to configure redirector port and FQDN through chart values

### DIFF
--- a/incubator/cms-xcache/cms-xcache/Chart.yaml
+++ b/incubator/cms-xcache/cms-xcache/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cms-xcache
 # Chart version
-version: 0.2.12
+version: 0.2.13
 description: XCache is a xrootd based caching service for k8s
 # Version of application packaged for installation
 appVersion: "4.11"

--- a/incubator/cms-xcache/cms-xcache/templates/deployment.yaml
+++ b/incubator/cms-xcache/cms-xcache/templates/deployment.yaml
@@ -106,6 +106,10 @@ spec:
             value: "{{ .Values.XCacheConfig.WQThreads }}"
           - name: DISABLE_OSG_MONITORING
             value: "{{ .Values.XCacheConfig.DisableOSGMonitoring }}"
+          - name: XC_REDIRECTOR_FQDN
+            value: "{{ .Values.XCacheConfig.XCRedirectorFQDN }}"
+          - name: XC_REDIRECTOR_PORT
+            value: "{{ .Values.XCacheConfig.XCRedirectorPort }}"
           resources:
             requests:
               ephemeral-storage: "5Gi"

--- a/incubator/cms-xcache/cms-xcache/values.yaml
+++ b/incubator/cms-xcache/cms-xcache/values.yaml
@@ -48,6 +48,9 @@ XCacheConfig:
   CertSecret: xcache-cert-secret
   # Disable OSG monitoring and reporting
   DisableOSGMonitoring: true
+  # Manager host and port for CMS Redirector 
+  XCRedirectorFQDN: redirector.example.edu
+  XCRedirectorPort: 1094
   LocalRoot: /xcache/namespace
   CacheDirectories:
     - path: /data1/xcache


### PR DESCRIPTION
Adds two values to `values.yaml`

-XCacheConfig.XCRedirectorFQDN
-XCacheConfig.XCRedirectorPort

Requires: https://github.com/opensciencegrid/docker-xcache/pull/61