### PR TITLE
[stable][osg-hosted-ce] Update file names for user credentials within app documentation

### DIFF
--- a/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.4.1"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.4.7
+version: 3.4.8

--- a/stable/osg-hosted-ce/osg-hosted-ce/README.md
+++ b/stable/osg-hosted-ce/osg-hosted-ce/README.md
@@ -395,7 +395,7 @@ Next you will need to convert it to PKCS12 format for voms. These commands will 
 
 Be sure that both files have the correct file permissions
 
-`chmod 600 hostkey.pem && chmod 600 usercert.pem`
+`chmod 600 userkey.pem && chmod 600 usercert.pem`
 
 ### Install HTCondorCE Client 
 

--- a/stable/osg-hosted-ce/osg-hosted-ce/README.md
+++ b/stable/osg-hosted-ce/osg-hosted-ce/README.md
@@ -389,13 +389,13 @@ Create a cert and download it. You'll need to remember the password you set.
 
 Next you will need to convert it to PKCS12 format for voms. These commands will prompt for your password.
 
-`openssl pkcs12 -in usercred.p12 -nocerts  -out hostkey.pem`
+`openssl pkcs12 -in usercred.p12 -nocerts  -out userkey.pem`
 
-`openssl pkcs12 -in usercred.p12 -nocerts -nodes -out hostkey.pem`
+`openssl pkcs12 -in usercred.p12 -nocerts -nodes -out usercert.pem`
 
 Be sure that both files have the correct file permissions
 
-`chmod 600 hostkey.pem && chmod 600 hostcert.pem`
+`chmod 600 hostkey.pem && chmod 600 usercert.pem`
 
 ### Install HTCondorCE Client 
 
@@ -413,7 +413,7 @@ Then install the tools
 
 You should be able to use your cert to initialize your grid proxy
 
-`voms-proxy-init -cert hostcert.pem -key hostkey.pem --debug`
+`voms-proxy-init -cert usercert.pem -key userkey.pem --debug`
 
 Here I use the `--debug` flag because `voms-proxy-init` won't give us very helpful output, if it fails.
 


### PR DESCRIPTION
File names for user credentials should match the Open Science Grid documentation

https://opensciencegrid.org/docs/security/user-certs/#certificate-formats

Closes #384 