### PR TITLE
[osg-hosted-ce][stable] Add persistence for /var/lib/condor-ce and /var/log/condor-ce

### DIFF
--- a/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.4.1"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.5.1
+version: 3.6.0

--- a/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.4.1"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.6.0
+version: 3.6.1

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -254,7 +254,9 @@ spec:
         - name: BOSCO_DIRECTORY
           value: {{ .Values.Topology.Resource }}
         {{ end }}
+        {{  if not .Values.Persistence.LibCondorCeVolume }}
         lifecycle:
           preStop:
             exec:
               command: ["/usr/local/bin/drain-ce.sh"]
+        {{ end }}

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -28,6 +28,11 @@ spec:
         kubernetes.io/hostname: {{ .Values.NodeSelection }}
       {{ end }}
       volumes:
+      {{ if .Values.Persistence.LibCondorCeVolume }}
+      - name: lib-condor-ce
+        persistentVolumeClaim:
+          claimName: {{ .Value.Persistence.LibCondorCeVolume }}
+      {{ end }}
       - name: osg-hosted-ce-{{ .Values.Instance }}-configuration
         configMap:
           name: osg-hosted-ce-{{ .Values.Instance }}-configuration
@@ -92,8 +97,14 @@ spec:
       {{ end }}
       {{ end }}
       {{ if .Values.HTTPLogger.Enabled }}
+      {{ if .Values.Persistence.LogVolume }}
+      - name: log-volume
+        persistentVolumeClaim:
+          claimName: {{ .Values.Persistence.LogVolume }}
+      {{ else }}
       - name: log-volume
         emptyDir: {} 
+      {{ end }}
       - name: osg-hosted-ce-{{ .Values.Instance }}-logger-startup
         configMap:
           name: osg-hosted-ce-{{ .Values.Instance }}-logger-startup
@@ -150,6 +161,10 @@ spec:
         - name: osg-hosted-ce-{{ .Values.Instance }}-htcondor-ce-configuration
           mountPath: /etc/condor-ce/config.d/99-instance.conf
           subPath: 99-instance.conf
+        {{ if .Values.Persistence.LibCondorCeVolume }}
+        - name: lib-condor-ce
+          mountPath: /var/lib/condor-ce
+        {{ end }}
         {{ if .Values.HostCredentials.HostCertKeySecret }}
         - name: osg-hosted-ce-hostcertkey-volume
           mountPath: /etc/grid-security/hostcert.pem

--- a/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -107,6 +107,15 @@ VoRemoteUserMapping:
 # HTCondorCeConfig: |+
 #   ALL_DEBUG = D_ALWAYS:2 D_CAT
 
+# Enable persistence to HostedCE files by creating corresponding SLATE Volumes
+# SLATE Creates a PVC in Kubernetes which can be reclaimed on restart
+# The value for each volume should correspond to the volume name within SLATE
+Persistence:
+  # /var/log/condor-ce
+  LogVolume: null 
+  # /var/lib/condor-ce
+  LibCondorCeVolume: null
+
 # Options to allow override of the bosco directory from arbitrary git repos
 # Bosco override dirs are expected in the following location in the git repo:
 #   <RESOURCE NAME>/bosco_override/


### PR DESCRIPTION
Optionally uses two SLATE Volumes to persist files across restarts of the application. 

-/var/lib/condor-ce
-/var/log/condor-ce

Adds two new chart values:
```
Persistence:
  LogVolume: null 
  LibCondorCeVolume: null
```