### PR TITLE
Update startup.sh

### DIFF
--- a/incubator/open-ondemand/images/open-ondemand/startup.sh
+++ b/incubator/open-ondemand/images/open-ondemand/startup.sh
@@ -38,5 +38,8 @@ supervisorctl restart apache
 #chmod 0600 /etc/sssd/sssd.conf
 #authconfig --update --enablesssd --enablesssdauth --enablemkhomedir
 # Add users from Keycloak API
-sleep 30
+while [ ! -f /shared/newusers.txt ]
+do
+	sleep 2
+done
 newusers /shared/newusers.txt


### PR DESCRIPTION
Changing startup script to check for existence of file /shared/newusers.txt before running newusers command, rather than running it after waiting 15 seconds.