### PR TITLE
Fix templating issue with Open OnDemand

### DIFF
--- a/incubator/open-ondemand/open-ondemand/Chart.yaml
+++ b/incubator/open-ondemand/open-ondemand/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: open-ondemand
 description: "Deploys an instance of Open OnDemand"
-version: 0.5.0
+version: 0.5.1
 appVersion: 1.8.1

--- a/incubator/open-ondemand/open-ondemand/templates/deployment.yaml
+++ b/incubator/open-ondemand/open-ondemand/templates/deployment.yaml
@@ -63,9 +63,11 @@ spec:
               mountPath: /etc/ood/config/clusters.d/cluster-{{ .cluster.name | lower | nospace }}.yml
               subPath: cluster-{{ .cluster.name | lower | nospace }}.yml
             # Desktop app
+            {{ if eq .cluster.desktopEnable true }}
             - name: cluster-{{ .cluster.name | lower | nospace }}-desktop-host
               mountPath: /etc/ood/config/apps/bc_desktop/single_cluster/desktop-{{ .cluster.name | lower | nospace }}.yml
               subPath: desktop-{{ .cluster.name | lower | nospace }}.yml
+            {{ end }}
             {{ end }}
           ports:
             - name: http

--- a/incubator/open-ondemand/open-ondemand/templates/desktop-host-configmap.yaml
+++ b/incubator/open-ondemand/open-ondemand/templates/desktop-host-configmap.yaml
@@ -10,8 +10,12 @@ data:
     title: {{ .cluster.name | lower | nospace }}-desktop
     cluster: {{ .cluster.name | lower | nospace | quote }}
     submit: "linux_host"
+    form:
+      - desktop
+      - bc_num_hours
     attributes:
       bc_queue: null
       bc_account: null
+      bc_num_slots: 1
       num_cores: none
   {{ end }}


### PR DESCRIPTION
OnDemand was missing an "if desktobEnable=true" statement that makes the container search for a missing volume when values.yaml has "desktopEnable: false". With this change desktop features can be properly disabled.

Also adding some extra config for the desktop application.