### PR TITLE
Frontier squid log n oacl

### DIFF
--- a/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
@@ -5,4 +5,4 @@ appVersion: 4.13-1.1
 description: A Helm chart for configuration and deployment of the Open Science Grid's Frontier Squid application.
 name: osg-frontier-squid
 # Chart version
-version: 1.5.1
+version: 1.5.2

--- a/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
@@ -5,4 +5,4 @@ appVersion: 4.13-1.1
 description: A Helm chart for configuration and deployment of the Open Science Grid's Frontier Squid application.
 name: osg-frontier-squid
 # Chart version
-version: 1.5.2
+version: 1.5.5

--- a/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
@@ -5,4 +5,4 @@ appVersion: 4.13-1.1
 description: A Helm chart for configuration and deployment of the Open Science Grid's Frontier Squid application.
 name: osg-frontier-squid
 # Chart version
-version: 1.5.0
+version: 1.5.1

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/configmap.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/configmap.yaml
@@ -19,10 +19,17 @@ data:
     {{- if .Values.SquidConf.Workers -}}
     setoption("workers", {{ .Values.SquidConf.Workers }} )
     setoption("cache_dir", "ufs /var/cache/squid/squid${process_number} {{ .Values.SquidConf.CacheSize }} 16 256")
+    {{- if .Values.SquidConf.DisableLogging -}}
+    setoption("access_log", "none")
+    {{- else -}}
     setoptionparameter("logformat awstats", 3, "kid${process_number}")
+    {{ end }}
     setoption("visible_hostname", "'`uname -n`'/${process_number}")
     {{- else }} # single worker case
     setoption("cache_dir", "ufs /var/cache/squid/squid {{ .Values.SquidConf.CacheSize }} 16 256")
+    {{- if .Values.SquidConf.DisableLogging -}}
+    setoption("access_log", "none")
+    {{- end }}
     {{ end }}
 # The below 60-image-post-init.sh script is not mounted and the above new script takes care of the customization needed
 # 2-3 setttings are done vai env vars as per the OSG docs

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/configmap.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/configmap.yaml
@@ -10,6 +10,10 @@ metadata:
 data:
   60-customization.awk: |
     setoption("acl HOST_MONITOR src", "{{ .Values.SquidConf.MonitoringIPRange }}")
+    {{- if .Values.SquidConf.RESTRICT_DEST }}
+    setoptionparameter("acl RESTRICT_DEST", 3, "{{ .Values.SquidConf.RESTRICT_DEST }}")
+    uncomment("http_access deny !RESTRICT_DEST")
+    {{- end }}
     {{ if .Values.SquidConf.Cpu_Affinity_Map }}setoption("cpu_affinity_map", "{{ .Values.SquidConf.Cpu_Affinity_Map }}"){{ end }}
     {{ if .Values.SquidConf.Logfile_Rotate }}setoption("logfile_rotate", "{{ .Values.SquidConf.Logfile_Rotate }}"){{ end }}
     {{- if .Values.SquidConf.Workers -}}

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
         {{ end }} 
         resources:
           requests:
-            cpu: {{ .Values.SquidConf.cpu }}
+            cpu: {{ .Values.SquidConf.CPU }}
             ephemeral-storage: {{ .Values.SquidConf.RequestEphemeralSize }}Gi
           limits:
             ephemeral-storage: {{ .Values.SquidConf.LimitEphemeralSize }}Gi

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
@@ -37,11 +37,11 @@ spec:
       containers:
       # Container for the primary application, OSG Frontier Squid
       - name: osg-frontier-squid
-        image: opensciencegrid/frontier-squid:fresh
+        image: opensciencegrid/frontier-squid:release
         imagePullPolicy: Always
         resources:
           requests:
-            cpu: "2"
+            cpu: {{ .Values.SquidConf.cpu }}
             ephemeral-storage: "2Gi"
           limits:
             ephemeral-storage: "5Gi"
@@ -60,6 +60,9 @@ spec:
         - containerPort: 3401
           name: monitoring
           protocol: UDP
+          {{ if and .Values.NodeSelection.Hostname .Values.NodeSelection.OpenDefaultMonPort }}
+          hostPort: 3401
+          {{ end }}
         volumeMounts:
 # Commetned out and will probably not be needed. We're using the default 60-image-post-init.sh script 
 # that comes with upstream image. Our custom config has been moved to the .awk file added through configmap

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
@@ -39,11 +39,21 @@ spec:
       - name: osg-frontier-squid
         image: opensciencegrid/frontier-squid:fresh
         imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: "2"
+            ephemeral-storage: "2Gi"
+          limits:
+            ephemeral-storage: "5Gi"
         env:
         - name: SQUID_IPRANGE
           value: {{ .Values.SquidConf.IPRange }}
         - name: SQUID_CACHE_MEM
           value: '{{ .Values.SquidConf.CacheMem }} MB'  
+        {{ if .Values.SquidConf.MaxAccessLog }}
+        - name: SQUID_MAX_ACCESS_LOG
+          value: {{ .Values.SquidConf.MaxAccessLog }}
+        {{ end }} 
         ports:
         - containerPort: 3128
           name: squid

--- a/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
@@ -66,6 +66,8 @@ SquidConf:
   # Docker/Kubernetes/SLATE log mechanisms, instead of to a file inside the container. 
   LogToStdout: True
 
+  # To disable logging, set the below flag to true
+  #DisableLogging: False
   # Set this if you want to run more than one cache process concurrently.
   # Cache memory/disk space is not shared; values configured above are per process. 
   #Workers: 4

--- a/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
@@ -84,5 +84,5 @@ NodeSelection:
   # Set this to null to be randomly assigned an available node 
   Hostname: null
   # Set the below flag to true if you want to expose defautl port on the target node
-  # Open default monitoring port (3401) -- This flag has no effect if Hostname is not set in this conf file 
+  # Open default monitoring port (3401) -- This flag has no effect if Hostname is not set above in this conf file.
   OpenDefaultMonPort: False

--- a/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
@@ -42,6 +42,8 @@ Service:
   #MonitoringNodePort: 31201
 
 SquidConf:
+  # The number of CPU cores allocated to the Squid application. The default is 2.
+  CPU: 2
   # The amount of memory (in MB) that Frontier Squid may use on the machine.
   # Per Frontier Squid, do not consume more than 1/8 of system memory with Frontier Squid
   CacheMem: 4096
@@ -82,8 +84,6 @@ SquidConf:
   Logfile_Rotate: "50"
   # Set the max size for the access log file
   MaxAccessLog: "20M"  
-  # Set the value for the cpu resource request - default is 2
-  cpu: "2"
 
 NodeSelection:  
   # Hostname (FQDN) for the cluster node you want this instance to schedule on.

--- a/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
@@ -77,6 +77,7 @@ SquidConf:
   MaxAccessLog: "20M"  
   # Set the value for the cpu resource request - default is 2
   cpu: "2"
+
 NodeSelection:  
   # Hostname (FQDN) for the cluster node you want this instance to schedule on.
   # This will also be the hostname used to access the squid if ExternalVisibility is set to NodePort

--- a/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
@@ -56,6 +56,8 @@ SquidConf:
   # The default set of ranges are those defined in RFC 1918 and typically used 
   # within kubernetes clusters. 
   IPRange: 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16
+  # The regular expressiion to restrict outbound traffic
+  #RESTRICT_DEST: "^(((cms|atlas).*frontier.*)\\.cern\\.ch)|frontier.*\\.racf\\.bnl\\.gov$"
   # The range of IP addresses that will be allowed to query the service's monitoring data.
   # Multiple ranges can be provided, each seperated by a space.
   # Example: 128.142.0.0/16 188.185.0.0/17
@@ -70,8 +72,9 @@ SquidConf:
   # This setting can be used to pin cache processes to CPU cores
   #Cpu_Affinity_Map: "process_numbers=1,2,3,4 cores=2,3,4,5"
   # Configure the number of names to use when rotating logfiles
-  #Logfile_Rotate: "10"
-  
+  Logfile_Rotate: "50"
+  # Set the max size for the access log file
+  MaxAccessLog: "20M"  
 NodeSelection:  
   # Hostname (FQDN) for the cluster node you want this instance to schedule on.
   # This will also be the hostname used to access the squid if ExternalVisibility is set to NodePort

--- a/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
@@ -75,6 +75,8 @@ SquidConf:
   Logfile_Rotate: "50"
   # Set the max size for the access log file
   MaxAccessLog: "20M"  
+  # Set the value for the cpu resource request - default is 2
+  cpu: "2"
 NodeSelection:  
   # Hostname (FQDN) for the cluster node you want this instance to schedule on.
   # This will also be the hostname used to access the squid if ExternalVisibility is set to NodePort

--- a/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
@@ -83,3 +83,6 @@ NodeSelection:
   # This will also be the hostname used to access the squid if ExternalVisibility is set to NodePort
   # Set this to null to be randomly assigned an available node 
   Hostname: null
+  # Set the below flag to true if you want to expose defautl port on the target node
+  # Open default monitoring port (3401) -- This flag has no effect if Hostname is not set in this conf file 
+  OpenDefaultMonPort: False


### PR DESCRIPTION
Summary of changes:
- Log rotation
- Option to restrict outbound traffic
- Making CPU requests configurable
- Use port 3401 on the target host as a monitoring port.
- Option to disable logging
- Pull 'release' instead of 'fresh OSG Frontier Squid docker image 