### PR TITLE
Frontier squid storage

### DIFF
--- a/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
@@ -5,4 +5,4 @@ appVersion: 4.13-1.1
 description: A Helm chart for configuration and deployment of the Open Science Grid's Frontier Squid application.
 name: osg-frontier-squid
 # Chart version
-version: 1.5.5
+version: 1.5.6

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
@@ -51,9 +51,9 @@ spec:
         resources:
           requests:
             cpu: {{ .Values.SquidConf.CPU }}
-            ephemeral-storage: {{ .Values.SquidConf.RequestEphemeralSize }}Gi
+            ephemeral-storage: {{ add .Values.SquidConf.RequestEphemeralSize  (div .Values.SquidConf.CacheSize 1000) }}Gi
           limits:
-            ephemeral-storage: {{ .Values.SquidConf.LimitEphemeralSize }}Gi
+            ephemeral-storage: {{ add .Values.SquidConf.LimitEphemeralSize  (div .Values.SquidConf.CacheSize 1000) }}Gi
         ports:
         - containerPort: 3128
           name: squid

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
@@ -51,9 +51,11 @@ spec:
         resources:
           requests:
             cpu: {{ .Values.SquidConf.CPU }}
-            ephemeral-storage: {{ add .Values.SquidConf.RequestEphemeralSize  (div .Values.SquidConf.CacheSize 1000) }}Gi
+# converting CacheSize to MiB and adding it to total request
+            ephemeral-storage: {{ add .Values.SquidConf.RequestEphemeralSize  (floor (div (mul .Values.SquidConf.CacheSize 9537) 10000))  }}Mi
           limits:
-            ephemeral-storage: {{ add .Values.SquidConf.LimitEphemeralSize  (div .Values.SquidConf.CacheSize 1000) }}Gi
+# converting CacheSize to MiB and adding it to total limit
+            ephemeral-storage: {{ add .Values.SquidConf.LimitEphemeralSize  (floor (div (mul .Values.SquidConf.CacheSize 9537) 10000))  }}Mi
         ports:
         - containerPort: 3128
           name: squid

--- a/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
@@ -52,8 +52,8 @@ SquidConf:
   # Current limit is 999999 MB, a limit inherent to helm's number conversion system.
   CacheSize: 10000
   # This is the total storage (in GiB) beyound the CacheSize. If logging disabled, 1 and 5
-  # would be reasonable values for request and limit. With logging enabled, higher values
-  # would be advisable if target cluster or node supports that.
+  # would be reasonable values for request and limit respectively. With logging enabled, higher
+  # values would be advisable if target cluster or node supports that.
   RequestEphemeralSize: 5
   LimitEphemeralSize: 15
   # The range of incoming IP addresses that will be allowed to use the proxy.

--- a/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
@@ -54,8 +54,8 @@ SquidConf:
   # This is the total storage (in GiB) beyound the CacheSize. If logging disabled, 1 and 5
   # would be reasonable values for request and limit respectively. With logging enabled, higher
   # values would be advisable if target cluster or node supports that.
-  RequestEphemeralSize: 5
-  LimitEphemeralSize: 15
+  RequestEphemeralSize: 3
+  LimitEphemeralSize: 10
   # The range of incoming IP addresses that will be allowed to use the proxy.
   # Multiple ranges can be provided, each seperated by a space.
   # Example: 192.168.1.1/32 192.168.2.1/32

--- a/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
@@ -51,9 +51,9 @@ SquidConf:
   # The default is 10000 MB (10 GB), but more is advisable if the system supports it.
   # Current limit is 999999 MB, a limit inherent to helm's number conversion system.
   CacheSize: 10000
-  # This is the total storage (in GiB) beyound the CacheSize. If you have have logging disabled, 1 and 5
-  # would be reasonable values for request and limit. With logging enabled, higher values would be advisable
-  # if target cluster or node supports it.
+  # This is the total storage (in GiB) beyound the CacheSize. If logging disabled, 1 and 5
+  # would be reasonable values for request and limit. With logging enabled, higher values
+  # would be advisable if target cluster or node supports that.
   RequestEphemeralSize: 5
   LimitEphemeralSize: 15
   # The range of incoming IP addresses that will be allowed to use the proxy.

--- a/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
@@ -54,7 +54,7 @@ SquidConf:
   # This is the total storage (in GiB) beyound the CacheSize. If logging disabled, 1 and 5
   # would be reasonable values for request and limit respectively. With logging enabled, higher
   # values would be advisable if target cluster or node supports that.
-  RequestEphemeralSize: 3
+  RequestEphemeralSize: 4
   LimitEphemeralSize: 10
   # The range of incoming IP addresses that will be allowed to use the proxy.
   # Multiple ranges can be provided, each seperated by a space.

--- a/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
@@ -51,11 +51,12 @@ SquidConf:
   # The default is 10000 MB (10 GB), but more is advisable if the system supports it.
   # Current limit is 999999 MB, a limit inherent to helm's number conversion system.
   CacheSize: 10000
-  # This is the total storage (in GiB) beyound the CacheSize. If logging disabled, 1 and 5
+  # This is the total storage (in MiB) beyound the CacheSize. If logging is disabled, 1024 and 5120
   # would be reasonable values for request and limit respectively. With logging enabled, higher
   # values would be advisable if target cluster or node supports that.
-  RequestEphemeralSize: 4
-  LimitEphemeralSize: 10
+  # The below default values assume that logging is enabled.
+  RequestEphemeralSize: 4026
+  LimitEphemeralSize: 10240
   # The range of incoming IP addresses that will be allowed to use the proxy.
   # Multiple ranges can be provided, each seperated by a space.
   # Example: 192.168.1.1/32 192.168.2.1/32

--- a/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
@@ -51,9 +51,11 @@ SquidConf:
   # The default is 10000 MB (10 GB), but more is advisable if the system supports it.
   # Current limit is 999999 MB, a limit inherent to helm's number conversion system.
   CacheSize: 10000
-  # this is 
-  RequestEphemeralSize: 10
-  LimitEphemeralSize: 20
+  # This is the total storage (in GiB) beyound the CacheSize. If you have have logging disabled, 1 and 5
+  # would be reasonable values for request and limit. With logging enabled, higher values would be advisable
+  # if target cluster or node supports it.
+  RequestEphemeralSize: 5
+  LimitEphemeralSize: 15
   # The range of incoming IP addresses that will be allowed to use the proxy.
   # Multiple ranges can be provided, each seperated by a space.
   # Example: 192.168.1.1/32 192.168.2.1/32
@@ -61,8 +63,10 @@ SquidConf:
   # The default set of ranges are those defined in RFC 1918 and typically used 
   # within kubernetes clusters. 
   IPRange: 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16
+
   # The regular expressiion to restrict outbound traffic
   #RESTRICT_DEST: "^(((cms|atlas).*frontier.*)\\.cern\\.ch)|frontier.*\\.racf\\.bnl\\.gov$"
+
   # The range of IP addresses that will be allowed to query the service's monitoring data.
   # Multiple ranges can be provided, each seperated by a space.
   # Example: 128.142.0.0/16 188.185.0.0/17
@@ -73,6 +77,7 @@ SquidConf:
 
   # To disable logging, set the below flag to true
   #DisableLogging: False
+
   # truncates log file every 2 minutes.
   CleanLog: False
   # Set this if you want to run more than one cache process concurrently.


### PR DESCRIPTION
Updated description for the ephemeral storage request and limit, and changed the default values and logic accordingly. Cachsize now gets added to whatever the user requests for container storage.