### PR TITLE
Frontier squid enhancement1

### DIFF
--- a/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
@@ -5,4 +5,4 @@ appVersion: 4.13-1.1
 description: A Helm chart for configuration and deployment of the Open Science Grid's Frontier Squid application.
 name: osg-frontier-squid
 # Chart version
-version: 1.5.7
+version: 1.5.8

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
@@ -93,7 +93,7 @@ spec:
           mountPath: /etc/localtime
           readOnly: true
         {{ end }}
-        {{ if .Values.SquidConf.UseHostpathLogDir }}
+        {{ if and .Values.SquidConf.UseHostpathLogDir .Values.NodeSelection.Hostname }}
         - name: squid-log-dir
           mountPath: /var/log/squid
         {{ end }}
@@ -132,7 +132,7 @@ spec:
           hostPath:
             path: /etc/localtime
         {{ end }}
-        {{ if .Values.SquidConf.UseHostpathLogDir }}
+        {{ if and .Values.SquidConf.UseHostpathLogDir .Values.NodeSelection.Hostname }}
         - name: squid-log-dir
           hostPath:
             path: /var/log/slate/hostPath/osg-frontier-squid

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
@@ -88,6 +88,11 @@ spec:
         - mountPath: /etc/squid/customize.d/60-customization.awk
           subPath: 60-customization.awk
           name: osg-frontier-squid-{{ .Values.Instance }}-awk
+        {{ if .Values.Pod.UseHostTimezone }}
+        - name: tz
+          mountPath: /etc/localtime
+          readOnly: true
+        {{ end }}
       volumes:
         - name: osg-frontier-squid-{{ .Values.Instance }}-awk
           configMap:
@@ -117,4 +122,9 @@ spec:
             claimName: osg-frontier-squid-{{ .Values.Instance }}-pvc
         {{ else }}
           emptyDir: {}
+        {{ end }}
+        {{ if .Values.Pod.UseHostTimezone }}
+        - name: tz
+          hostPath:
+            path: /etc/localtime
         {{ end }}

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
@@ -93,6 +93,10 @@ spec:
           mountPath: /etc/localtime
           readOnly: true
         {{ end }}
+        {{ if .Values.SquidConf.UseHostpathLogDir }}
+        - name: squid-log-dir
+          mountPath: /var/log/squid
+        {{ end }}
       volumes:
         - name: osg-frontier-squid-{{ .Values.Instance }}-awk
           configMap:
@@ -127,4 +131,10 @@ spec:
         - name: tz
           hostPath:
             path: /etc/localtime
+        {{ end }}
+        {{ if .Values.SquidConf.UseHostpathLogDir }}
+        - name: squid-log-dir
+          hostPath:
+            path: /var/log/slate/hostPath/osg-frontier-squid
+            type: Directory
         {{ end }}

--- a/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
@@ -97,6 +97,8 @@ SquidConf:
   UseHostpathLogDir: false
 
 Pod:
+  # Set to true if you want to use the host's timezone settings. This would affect the timestamps of log messages.
+  # Default timezone is UTC.
   UseHostTimezone: false
 
 NodeSelection:  

--- a/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
@@ -91,15 +91,11 @@ SquidConf:
   Logfile_Rotate: "30"
   # Set the max size for the access log file
   MaxAccessLog: "20M"  
-  # Use local hostpath log dir (need to be set by cluster admin before squid deployment)
+  # Use local hostpath log dir
   # The directory "/var/log/slate/hostPath/osg-frontier-squid" must exist with rwx
-  # permissions for uid:10941
+  # permissions for uid:10941 on the target node.
+  # This configuration has no effect when NodeSelection.Hostname is not set below.
   UseHostpathLogDir: false
-
-Pod:
-  # Set to true if you want to use the host's timezone settings. This would affect the timestamps of log messages.
-  # Default timezone is UTC.
-  UseHostTimezone: false
 
 NodeSelection:  
   # Hostname (FQDN) for the cluster node you want this instance to schedule on.
@@ -109,3 +105,8 @@ NodeSelection:
   # Set the below flag to true if you want to expose defautl port on the target node
   # Open default monitoring port (3401) -- This flag has no effect if Hostname is not set above in this conf file.
   OpenDefaultMonPort: False
+
+Pod:
+  # Set to true if you want to use the host's timezone settings. This would affect the timestamps of log messages.
+  # Default timezone is UTC.
+  UseHostTimezone: false

--- a/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
@@ -56,8 +56,8 @@ SquidConf:
   # for request and limit respectively. With logging enabled and Pod.UseHostpathLogDir set
   # to false, higher values would be advisable if target cluster or node supports that.
   # The below default values assume that logging is enabled.
-  RequestEphemeralSize: 8026
-  LimitEphemeralSize: 12240
+  RequestEphemeralSize: 7000
+  LimitEphemeralSize: 12000
   # The range of incoming IP addresses that will be allowed to use the proxy.
   # Multiple ranges can be provided, each seperated by a space.
   # Example: 192.168.1.1/32 192.168.2.1/32

--- a/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
@@ -51,9 +51,10 @@ SquidConf:
   # The default is 10000 MB (10 GB), but more is advisable if the system supports it.
   # Current limit is 999999 MB, a limit inherent to helm's number conversion system.
   CacheSize: 10000
-  # This is the total storage (in MiB) beyound the CacheSize. If logging is disabled, 1024 and 5120
-  # would be reasonable values for request and limit respectively. With logging enabled, higher
-  # values would be advisable if target cluster or node supports that.
+  # This is the total storage (in MiB) beyound the CacheSize. If logging is disabled or if
+  # Pod.UseHostpathLogDir set to true(see below), 1024 and 5120 would be reasonable values
+  # for request and limit respectively. With logging enabled and Pod.UseHostpathLogDir set
+  # to false, higher values would be advisable if target cluster or node supports that.
   # The below default values assume that logging is enabled.
   RequestEphemeralSize: 8026
   LimitEphemeralSize: 12240
@@ -87,9 +88,13 @@ SquidConf:
   # This setting can be used to pin cache processes to CPU cores
   #Cpu_Affinity_Map: "process_numbers=1,2,3,4 cores=2,3,4,5"
   # Configure the number of names to use when rotating logfiles
-  Logfile_Rotate: "50"
+  Logfile_Rotate: "30"
   # Set the max size for the access log file
   MaxAccessLog: "20M"  
+  # Use local hostpath log dir (need to be set by cluster admin before squid deployment)
+  # The directory "/var/log/slate/hostPath/osg-frontier-squid" must exist with rwx
+  # permissions for uid:10941
+  UseHostpathLogDir: false
 
 Pod:
   UseHostTimezone: false

--- a/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
@@ -55,8 +55,8 @@ SquidConf:
   # would be reasonable values for request and limit respectively. With logging enabled, higher
   # values would be advisable if target cluster or node supports that.
   # The below default values assume that logging is enabled.
-  RequestEphemeralSize: 4026
-  LimitEphemeralSize: 10240
+  RequestEphemeralSize: 8026
+  LimitEphemeralSize: 12240
   # The range of incoming IP addresses that will be allowed to use the proxy.
   # Multiple ranges can be provided, each seperated by a space.
   # Example: 192.168.1.1/32 192.168.2.1/32
@@ -90,6 +90,9 @@ SquidConf:
   Logfile_Rotate: "50"
   # Set the max size for the access log file
   MaxAccessLog: "20M"  
+
+Pod:
+  UseHostTimezone: false
 
 NodeSelection:  
   # Hostname (FQDN) for the cluster node you want this instance to schedule on.


### PR DESCRIPTION
These changes give the user options to:
- Use the host local timezone for container and log messages
- Use host path log directory to retain log messages when the squid pod restarts