### PR TITLE
Need to harmonize SLATE volumes w/ HostPath 

### DIFF
--- a/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
@@ -5,4 +5,4 @@ appVersion: 4.13-1.1
 description: A Helm chart for configuration and deployment of the Open Science Grid's Frontier Squid application.
 name: osg-frontier-squid
 # Chart version
-version: 1.5.11
+version: 1.5.12

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
@@ -88,11 +88,6 @@ spec:
           mountPath: /etc/supervisord.d/55-squid-log-clean.conf
           subPath: 55-squid-log-clean.conf 
         {{ end }}
-        # Storage location of the cache data
-        {{ 
-        - mountPath: /var/cache/squid/osg-frontier-squid-{{ .Values.Instance }}-cache
-          subPath: osg-frontier-squid-{{ .Values.Instance }}-cache
-          name: osg-frontier-squid-{{ .Values.Instance }}-data
         - mountPath: /etc/squid/customize.d/60-customization.awk
           subPath: 60-customization.awk
           name: osg-frontier-squid-{{ .Values.Instance }}-awk

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
@@ -74,7 +74,10 @@ spec:
         {{ if .Values.SquidConf.CacheDirOnHost }}
         - name: osg-frontier-squid-{{ .Values.Instance }}-cachedir
           mountPath: /var/cache/squid 
-        {{ end }}
+        {{ else if .Values.SLATE.LocalStorage }}
+        - mountPath: /var/cache/squid
+          name: osg-frontier-squid-{{ .Values.Instance }}-data
+        {{ end }} 
         {{ if .Values.SquidConf.LogToStdout }}
         - name: osg-frontier-squid-{{ .Values.Instance }}-conf
           mountPath: /etc/supervisord.d/50-squid-log-dump.conf
@@ -86,6 +89,7 @@ spec:
           subPath: 55-squid-log-clean.conf 
         {{ end }}
         # Storage location of the cache data
+        {{ 
         - mountPath: /var/cache/squid/osg-frontier-squid-{{ .Values.Instance }}-cache
           subPath: osg-frontier-squid-{{ .Values.Instance }}-cache
           name: osg-frontier-squid-{{ .Values.Instance }}-data


### PR DESCRIPTION
We need to make SLATE volume support work harmoniously with hostPath support.

Does this change resolve that? Are there any other issues? 

Wondering if the Instance name is really needed.. do multiple squid workers share a cache or build their own cache? I would assume the former.