### PR TITLE
Use "Recreate" instead of "RollingUpdate" for CEs

### DIFF
--- a/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.4.1"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.8.2
+version: 3.9.0

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       chart: {{ template "osg-hosted-ce.chart" . }}
       release: {{ .Release.Name }}
       instance: {{ .Values.Instance }}
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels: 


### PR DESCRIPTION
1.  We definitely want recreate when using PVCs since we don't want
two sets of daemons using the same dirs, concurrently
2.  Operators have to 'slate instance delete' first anyway so
RollingUpdate doesn't actually do anything