### PR TITLE
Incubator Hosted CE: drop chart label

### DIFF
--- a/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.4.1"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.8.2
+version: 3.9.0

--- a/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.4.1"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.9.0
+version: 3.9.1

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -4,7 +4,6 @@ metadata:
   name: osg-hosted-ce-{{ .Values.Instance }}-configuration
   labels:
     app: osg-hosted-ce
-    chart: {{ template "osg-hosted-ce.chart" . }}
     instance: {{ .Values.Instance }}
     release: {{ .Release.Name }}
 data:
@@ -57,7 +56,6 @@ metadata:
   name: osg-hosted-ce-{{ .Values.Instance }}-htcondor-ce-configuration
   labels:
     app: osg-hosted-ce
-    chart: {{ template "osg-hosted-ce.chart" . }}
     instance: {{ .Values.Instance }}
     release: {{ .Release.Name }}
 data:
@@ -99,7 +97,6 @@ metadata:
   name: osg-hosted-ce-{{ .Values.Instance }}-voms-mapfile
   labels:
     app: osg-hosted-ce
-    chart: {{ template "osg-hosted-ce.chart" . }}
     instance: {{ .Values.Instance }}
     release: {{ .Release.Name }}
 data:
@@ -117,7 +114,6 @@ metadata:
   name: osg-hosted-ce-{{ .Values.Instance }}-grid-mapfile
   labels:
     app: osg-hosted-ce
-    chart: {{ template "osg-hosted-ce.chart" . }}
     instance: {{ .Values.Instance }}
     release: {{ .Release.Name }}
 data:
@@ -136,7 +132,6 @@ metadata:
   name: osg-hosted-ce-{{ .Values.Instance }}-slate-scitokens
   labels:
     app: osg-hosted-ce
-    chart: {{ template "osg-hosted-ce.chart" . }}
     instance: {{ .Values.Instance }}
     release: {{ .Release.Name }}
 data:
@@ -155,7 +150,6 @@ metadata:
   name: osg-hosted-ce-{{ .Values.Instance }}-logger-startup
   labels:
     app: osg-hosted-ce
-    chart: {{ template "osg-hosted-ce.chart" . }}
     instance: {{ .Values.Instance }}
     release: {{ .Release.Name }}
 data:

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ template "osg-hosted-ce.fullname" . }}
   labels:
     app: {{ template "osg-hosted-ce.name" . }}
-    chart: {{ template "osg-hosted-ce.chart" . }}
     release: {{ .Release.Name }}
     instance: {{ .Values.Instance }}
     instanceID: {{ .Values.SLATE.Instance.ID | quote  }}
@@ -13,7 +12,6 @@ spec:
   selector:
     matchLabels:
       app: {{ template "osg-hosted-ce.name" . }}
-      chart: {{ template "osg-hosted-ce.chart" . }}
       release: {{ .Release.Name }}
       instance: {{ .Values.Instance }}
   strategy:
@@ -22,7 +20,6 @@ spec:
     metadata:
       labels: 
         app: {{ template "osg-hosted-ce.name" . }}
-        chart: {{ template "osg-hosted-ce.chart" . }}
         release: {{ .Release.Name }}
         instance: {{ .Values.Instance }}
     spec:

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       chart: {{ template "osg-hosted-ce.chart" . }}
       release: {{ .Release.Name }}
       instance: {{ .Values.Instance }}
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels: 
@@ -253,7 +255,7 @@ spec:
           value: {{ .Values.RemoteCluster.Batch | lower }}
         - name: REMOTE_BOSCO_DIR
           value: {{ .Values.RemoteCluster.BoscoDir | default "bosco" }}
-        {{ if .Values.BoscoOverrides.URL }}
+        {{ if .Values.BoscoOverrides.TarballURL }}
         - name: BOSCO_TARBALL_URL
           value: {{ .Values.BoscoOverrides.TarballURL }}
         {{ end }}

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/service.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/service.yaml
@@ -5,7 +5,6 @@ metadata:
   name: {{ template "osg-hosted-ce.fullname" . }}
   labels:
     app: {{ template "osg-hosted-ce.name" . }}
-    chart: {{ template "osg-hosted-ce.chart" . }}
     release: {{ .Release.Name }}
     instance: {{ .Values.Instance }}
   annotations:

--- a/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -103,6 +103,17 @@ VoRemoteUserMapping:
 #DnRemoteUserMapping:
 #  - "/DC=foo/DC=bar/OU=Organic Units/OU=Users/CN=YourUserName": osg01
 
+# SCITOKENS url to user mapping
+# SciTokenRemoteUserMapping:
+    # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/OSG.yaml
+    # - "https://scitokens.org/osg-connect": osg01
+    # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/GLOW.yaml
+    # - "https://chtc.cs.wisc.edu": osg02
+    # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/CMS.yaml
+    # - "https://cms-auth.web.cern.ch/": osg04
+    # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/ATLAS.yaml
+    # - "https://atlas-auth.web.cern.ch/": osg09
+
 # Specify additional HTCondor-CE configuration
 # HTCondorCeConfig: |+
 #   ALL_DEBUG = D_ALWAYS:2 D_CAT


### PR DESCRIPTION
I opted to drop the label entirely instead of using `{{ template "osg-hosted-ce.chart" . }}` since that'd just duplicate the `app` label