### PR TITLE
Squid image selection

### DIFF
--- a/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
@@ -5,4 +5,4 @@ appVersion: 4.13-1.1
 description: A Helm chart for configuration and deployment of the Open Science Grid's Frontier Squid application.
 name: osg-frontier-squid
 # Chart version
-version: 1.5.14
+version: 1.6.0

--- a/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
@@ -5,4 +5,4 @@ appVersion: 4.13-1.1
 description: A Helm chart for configuration and deployment of the Open Science Grid's Frontier Squid application.
 name: osg-frontier-squid
 # Chart version
-version: 1.5.13
+version: 1.5.14

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/configmap.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/configmap.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ template "osg-frontier-squid.fullname" . }}
   labels:
     app: {{ template "osg-frontier-squid.name" . }}
-    chart: {{ template "osg-frontier-squid.chart" . }}
     release: {{ .Release.Name }}
     instance: {{ .Values.Instance | quote }}
 data:

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ template "osg-frontier-squid.fullname" . }}
   labels:
     app: {{ template "osg-frontier-squid.name" . }}
-    chart: {{ template "osg-frontier-squid.chart" . }}
     release: {{ .Release.Name }}
     instance: {{ .Values.Instance | quote }}
 
@@ -13,7 +12,6 @@ spec:
   selector:
     matchLabels:
       app: {{ template "osg-frontier-squid.name" . }}
-      chart: {{ template "osg-frontier-squid.chart" . }}
       release: {{ .Release.Name }}
       instance: {{ .Values.Instance | quote }}
 
@@ -21,7 +19,6 @@ spec:
     metadata:
       labels:
         app: {{ template "osg-frontier-squid.name" . }}
-        chart: {{ template "osg-frontier-squid.chart" . }}
         release: {{ .Release.Name }}
         instance: {{ .Values.Instance | quote }}
     spec:
@@ -37,7 +34,7 @@ spec:
       containers:
       # Container for the primary application, OSG Frontier Squid
       - name: osg-frontier-squid
-        image: opensciencegrid/frontier-squid:release
+        image: "opensciencegrid/frontier-squid:{{ .Values.ImageTag | default "release" }}"
         imagePullPolicy: Always
         env:
         - name: SQUID_IPRANGE

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/pvc.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/pvc.yaml
@@ -5,7 +5,6 @@ metadata:
   name: osg-frontier-squid-{{ .Values.Instance }}-pvc
   labels:
     app: {{ template "osg-frontier-squid.name" . }}
-    chart: {{ template "osg-frontier-squid.chart" . }}
     release: {{ .Release.Name }}
     instance: {{ .Values.Instance | quote }}
 spec:

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/service.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/service.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ template "osg-frontier-squid.fullname" . }}
   labels:
     app: {{ template "osg-frontier-squid.name" . }}
-    chart: {{ template "osg-frontier-squid.chart" . }}
     release: {{ .Release.Name }}
     instance: {{ .Values.Instance | quote }}
 spec:
@@ -14,7 +13,6 @@ spec:
   {{ end }}
   selector:
     app: {{ template "osg-frontier-squid.name" . }}
-    chart: {{ template "osg-frontier-squid.chart" . }}
     release: {{ .Release.Name }}
     instance: {{ .Values.Instance | quote }}
   ports:

--- a/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
@@ -12,6 +12,11 @@ SLATE:
   LocalStorage: false
 ### SLATE-END ###
 
+# Supported values are e.g. 'release' or 'testing' or 'development'. Default is
+# 'release'. Consult the opensciencegrid/frontier-squid docker image for other
+# tags.
+#ImageTag: release
+
 Service:
   # Port that the service will utilize.
   Port: 3128


### PR DESCRIPTION
Removed the problematic "Chart" label from the squid chart

Added new ImageTag parameter, with a default of 'release' so nothing changes for current instances. But new instances can select an alternate tag.