### PR TITLE
Allow HTCondor-CE more time to clean up after itself

### DIFF
--- a/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.4.1"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.9.5
+version: 3.9.6

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -273,4 +273,5 @@ spec:
           preStop:
             exec:
               command: ["/usr/local/bin/drain-ce.sh"]
+      terminationGracePeriodSeconds: 120
         {{ end }}


### PR DESCRIPTION
We noticed a site with 3.3k sandbox dirs on the remote login node,
most of which were stale. Job removal should eventually clean up the
sandbox dirs so let's extend the termination time to ensure HTCondor
can do its job.