### PR TITLE
Some quick changes for dir-mounted cert/key

### DIFF
--- a/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.4.1"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.9.7
+version: 3.9.8

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
           secretName: {{ .Values.HostCredentials.HostCertKeySecret }}
           items:
           - key: tls.crt
-            mode: 256
+            mode: 420
           - key: tls.key
             mode: 256
       {{ else }}

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -65,10 +65,8 @@ spec:
           secretName: {{ .Values.HostCredentials.HostCertKeySecret }}
           items:
           - key: tls.crt
-            path: hostcert.pem
             mode: 256
           - key: tls.key
-            path: hostkey.pem
             mode: 256
       {{ else }}
       {{ if and .Values.HostCredentials.HostCertSecret .Values.HostCredentials.HostKeySecret }}


### PR DESCRIPTION
I'm not sure if leaving out the `path` is legal but we don't really need to rename the secret item names