### PR TITLE
Just kidding, paths are required in the secret

### DIFF
--- a/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.4.1"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.9.8
+version: 3.9.9

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -65,8 +65,10 @@ spec:
           secretName: {{ .Values.HostCredentials.HostCertKeySecret }}
           items:
           - key: tls.crt
+            path: hostcert.pem
             mode: 420
           - key: tls.key
+            path: hostkey.pem
             mode: 256
       {{ else }}
       {{ if and .Values.HostCredentials.HostCertSecret .Values.HostCredentials.HostKeySecret }}


### PR DESCRIPTION
You can only skip them if you don't specify `items` altogether