### PR TITLE
Make changes to Telegraf application

### DIFF
--- a/incubator/telegraf/telegraf/Chart.yaml
+++ b/incubator/telegraf/telegraf/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: telegraf
-version: 0.5.0
+version: 0.6.0
 appVersion: 1.17.0
 description: "Deploys an SNMP monitoring service using Telegraf."

--- a/incubator/telegraf/telegraf/README.md
+++ b/incubator/telegraf/telegraf/README.md
@@ -94,6 +94,8 @@ The following table lists the configurable parameters of the Telegraf monitoring
 |`grnocOutput.username`| Database username |`tsds username`|
 |`grnocOutput.password`| Database password |`tsds password`|
 |`targets.hostGroup.community`| Community string of `hostGroup` |`public`|
+|`targets.hostGroup.timeout`| SNMP timeout length of `hostGroup` |`15s`|
+|`targets.hostGroup.retries`| Number of retries to attempt for `hostGroup` |`2`|
 |`targets.hostGroup.hosts`| Hosts to monitor |`127.0.0.1:161`|
 |`targets.hostGroup.counter64bit`| Type of SNMP counter on host machine |`false`|
 |`targets.hostGroup.oids`| SNMP OIDs to poll |*telegraf configuration monitoring system uptime*|

--- a/incubator/telegraf/telegraf/README.md
+++ b/incubator/telegraf/telegraf/README.md
@@ -22,6 +22,12 @@ slate app get-conf telegraf > telegraf.yaml
 
 Next, modify the configuration file with your preferred editor to ensure appropriate configuration. A guide to this can be found [here](https://slateci.io/blog/telegraf-monitoring.html).
 
+Then, if you are writing to GlobalNOC's database, create a SLATE secret containing your database password.
+This is done with the following command:
+```bash
+slate secret create --from-literal password=<your_password> <secret_name>
+```
+
 Finally, install the app with your custom configuration onto a SLATE cluster.
 Use a command that looks something like this: 
 
@@ -92,7 +98,7 @@ The following table lists the configurable parameters of the Telegraf monitoring
 |`grnocOutput.enabled`| Whether to write to GlobalNOC database |`true`|
 |`grnocOutput.hostname`| Database endpoint |`tsds.hostname.net`|
 |`grnocOutput.username`| Database username |`tsds username`|
-|`grnocOutput.password`| Database password |`tsds password`|
+|`grnocOutput.passwordSecretName`| GlobalNOC database password secret name |`tsds-password-secret`|
 |`targets.hostGroup.community`| Community string of `hostGroup` |`public`|
 |`targets.hostGroup.timeout`| SNMP timeout length of `hostGroup` |`15s`|
 |`targets.hostGroup.retries`| Number of retries to attempt for `hostGroup` |`2`|

--- a/incubator/telegraf/telegraf/README.md
+++ b/incubator/telegraf/telegraf/README.md
@@ -25,7 +25,7 @@ Next, modify the configuration file with your preferred editor to ensure appropr
 Then, if you are writing to GlobalNOC's database, create a SLATE secret containing your database password.
 This is done with the following command:
 ```bash
-slate secret create --from-literal password=<your_password> <secret_name>
+slate secret create --group <slate_group> --cluster <slate_cluster> --from-literal password=<your_password> <secret_name>
 ```
 
 Finally, install the app with your custom configuration onto a SLATE cluster.

--- a/incubator/telegraf/telegraf/templates/configmap.yaml
+++ b/incubator/telegraf/telegraf/templates/configmap.yaml
@@ -26,8 +26,6 @@ data:
     sed -e "s/passwordPlaceholder/$GRNOC_DATABASE_PASSWORD/" /etc/setup/config.yaml > /etc/telegraf/conf.d/config.yaml
     {{ end }}
 
-    # Restart telegraf? TODO
-
 
   {{ if eq .Values.grnocOutput.enabled true }}
 

--- a/incubator/telegraf/telegraf/templates/configmap.yaml
+++ b/incubator/telegraf/telegraf/templates/configmap.yaml
@@ -16,6 +16,8 @@ data:
 
     #! /bin/bash 
 
+    mkdir -p /etc/telegraf/conf.d/
+
     # Copy configuration file to proper location
     cp /etc/setup/telegraf.conf  /etc/telegraf/conf.d/telegraf.conf
 

--- a/incubator/telegraf/telegraf/templates/configmap.yaml
+++ b/incubator/telegraf/telegraf/templates/configmap.yaml
@@ -12,13 +12,29 @@ metadata:
 
 # store Telegraf configuration file
 data:
+  "setup.sh": |-
+
+    #! /bin/bash 
+
+    # Copy configuration file to proper location
+    cp /etc/setup/telegraf.conf  /etc/telegraf/conf.d/telegraf.conf
+
+    {{ if eq .Values.grnocOutput.enabled true }}
+    # Create edited configuration file
+    sed -e "s/passwordPlaceholder/$GRNOC_DATABASE_PASSWORD/" /etc/setup/config.yaml > /etc/telegraf/conf.d/config.yaml
+    {{ end }}
+
+    # Restart telegraf? TODO
+
+
   {{ if eq .Values.grnocOutput.enabled true }}
+
   "config.yaml": |-
 
     credentials:
       url: {{ .Values.grnocOutput.hostname | quote }}
-      username: {{ .Values.grnocOutput.username | quote }}
-      password: {{ .Values.grnocOutput.password | quote }}
+      username: {{ .Values.grnocOutput.username }}
+      password: passwordPlaceholder
 
     data:
       - tsds_name: interface

--- a/incubator/telegraf/telegraf/templates/configmap.yaml
+++ b/incubator/telegraf/telegraf/templates/configmap.yaml
@@ -23,7 +23,7 @@ data:
     data:
       - tsds_name: interface
         telegraf_name: interface
-        interval: {{ .Values.flushInterval }}
+        interval: 60 # possibly make this configurable later if it's something that is necessary
         metadata:
           - from: agent_host
             to: "node"
@@ -167,11 +167,13 @@ data:
       "{{ $value }}",
       {{ end -}}]
 
-      timeout = "15s"
+      timeout = {{ .hostGroup.timeout | quote }}
       version = 2
+
       # SNMP community string.
       community = {{ .hostGroup.community | quote }}
-      retries = 2
+      # Number of retries to attempt.
+      retries = {{ .hostGroup.retries }}
       max_repetitions = 15
 
       # Poll custom OIDs if grnoc output is disabled.

--- a/incubator/telegraf/telegraf/templates/deployment.yaml
+++ b/incubator/telegraf/telegraf/templates/deployment.yaml
@@ -30,10 +30,22 @@ spec:
           image: karlnewell/tsds-telegraf
           imagePullPolicy: Always
           volumeMounts:
-            - mountPath: /etc/telegraf/conf.d
+            - mountPath: /etc/setup/
               name: telegraf-volume 
+          lifecycle:
+            postStart:
+              exec:
+                # This script will create the appropriate "config.yaml" file for the grnoc output plugin
+                command: ["/bin/bash", "/etc/setup/grnoc-plugin-setup.sh"]
+          env:
+            - name: GRNOC_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.grnocOutput.passwordSecretName }}
+                  key: username
       volumes:
         - name: telegraf-volume
           # populate volume with config map data
           configMap:
             name: telegraf-{{ .Values.Instance }}-configuration
+

--- a/incubator/telegraf/telegraf/templates/deployment.yaml
+++ b/incubator/telegraf/telegraf/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
             postStart:
               exec:
                 # This script will create the appropriate "config.yaml" file for the grnoc output plugin
-                command: ["/bin/bash", "/etc/setup/grnoc-plugin-setup.sh"]
+                command: ["/bin/bash", "/etc/setup/setup.sh"]
           env:
             - name: GRNOC_DATABASE_PASSWORD
               valueFrom:

--- a/incubator/telegraf/telegraf/templates/deployment.yaml
+++ b/incubator/telegraf/telegraf/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.grnocOutput.passwordSecretName }}
-                  key: username
+                  key: password
       volumes:
         - name: telegraf-volume
           # populate volume with config map data

--- a/incubator/telegraf/telegraf/templates/deployment.yaml
+++ b/incubator/telegraf/telegraf/templates/deployment.yaml
@@ -37,12 +37,14 @@ spec:
               exec:
                 # This script will create the appropriate "config.yaml" file for the grnoc output plugin
                 command: ["/bin/bash", "/etc/setup/setup.sh"]
+          {{ if eq .Values.grnocOutput.enabled true }}
           env:
             - name: GRNOC_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.grnocOutput.passwordSecretName }}
                   key: password
+          {{ end }}
       volumes:
         - name: telegraf-volume
           # populate volume with config map data

--- a/incubator/telegraf/telegraf/values.yaml
+++ b/incubator/telegraf/telegraf/values.yaml
@@ -36,8 +36,13 @@ grnocOutput:
 
 
 # Specify hosts to monitor here. Hosts can be IP addresses or DNS names.
-# A hostGroup is a group of hosts that share settings. (e.g. community string, oids)
-# Port must also be specififed with a colon after hostname or address. (default is 161)
+# A hostGroup is a group of hosts that share settings. (e.g. community string, oids, retries, and timeout)
+# The "timeout" parameter adjusts how long it takes before an SNMP request is considered failed.
+# Set this by specifying an integer and "s" afterwards, for seconds.
+# The "retries" parameter specifies how many retries to attempt in the case of a failed SNMP request.
+# Simply use an integer here.
+#
+# A port must also be specififed with a colon after hostname or address. (default is 161, and should probably not be changed)
 # Specify OIDs according to the Telegraf SNMP plugin format.
 # Documentation can be found at: https://github.com/influxdata/telegraf/tree/master/plugins/inputs/snmp.
 # The counter64Bit parameter is only relevant if GRNOC output has been enabled.
@@ -51,6 +56,9 @@ grnocOutput:
 targets:
   - hostGroup:
       community: "public"
+      timeout: "15s"
+      retries: 2
+      community: "public"
       hosts:
         - "127.0.0.1"
       counter64Bit: false
@@ -60,6 +68,8 @@ targets:
           name = "uptime"
   - hostGroup:
       community: "public"
+      timeout: "15s"
+      retries: 2
       hosts:
         - "127.0.0.1"
         - "localhost"

--- a/incubator/telegraf/telegraf/values.yaml
+++ b/incubator/telegraf/telegraf/values.yaml
@@ -32,7 +32,7 @@ grnocOutput:
   enabled: true
   hostname: "tsds.hostname.net"
   username: "tsds username"
-  password: "tsds password"
+  passwordSecretName: "tsds-password-secret"
 
 
 # Specify hosts to monitor here. Hosts can be IP addresses or DNS names.

--- a/incubator/telegraf/telegraf/values.yaml
+++ b/incubator/telegraf/telegraf/values.yaml
@@ -59,7 +59,6 @@ targets:
       community: "public"
       timeout: "15s"
       retries: 2
-      community: "public"
       hosts:
         - "127.0.0.1"
       counter64Bit: false

--- a/incubator/telegraf/telegraf/values.yaml
+++ b/incubator/telegraf/telegraf/values.yaml
@@ -25,7 +25,8 @@ flushJitter: "10s"
 
 # Configuration for GlobalNOC database output
 # Set enabled flag to true to enable GlobalNOC output.
-# Set hostname, username, and password accordingly.
+# Set hostname, and username accordingly.
+# Set passwordSecretName to the name of a previously created SLATE secret. (see README)
 # Note that enabling GRNOC output results in a pre-defined set of
 # OIDs being polled, and will override user-specified OIDs.
 grnocOutput:


### PR DESCRIPTION
Updates the Telegraf monitoring application to expose two additional values.
Also removes the GRNOC password from the `values.yaml` file and uses a SLATE secret instead.