### PR TITLE
Update configmap.yaml

### DIFF
--- a/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
@@ -5,4 +5,4 @@ appVersion: 4.13-1.1
 description: A Helm chart for configuration and deployment of the Open Science Grid's Frontier Squid application.
 name: osg-frontier-squid
 # Chart version
-version: 1.7.1
+version: 1.7.2

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/configmap.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/configmap.yaml
@@ -50,7 +50,7 @@ data:
     {{ if .Values.SquidConf.DiskCacheMinObjSize }}
     setoption("cache_dir", "ufs /var/cache/squid/squid {{ .Values.SquidConf.CacheSize }} 16 256 min_size={{ .Values.SquidConf.DiskCacheMinObjSize }}")
     {{ else if .Values.SquidConf.DisableDiskCache }}
-    setoption("cache_dir", "null")
+    setoption("cache_dir", "none /var/cache/squid/squid {{ .Values.SquidConf.CacheSize }} 16 256")
     {{ else }}
     setoption("cache_dir", "ufs /var/cache/squid/squid {{ .Values.SquidConf.CacheSize }} 16 256")
     {{ end }} 


### PR DESCRIPTION
Undoing changes. Using null results in the following crash:

```
2021/06/01 18:09:03| FATAL: Bungled /etc/squid/squid.conf line 3531: cache_dir null
2021/06/01 18:09:03| Squid Cache (Version frontier-squid-4.15-1.2.osg35.el8): Terminated abnormally.
CPU Usage: 0.010 seconds = 0.009 user + 0.001 sys
```