### PR TITLE
Allow operators to specify an SSH certificate secret (SOFTWARE-4850)

### DIFF
--- a/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "5.1.0"
+appVersion: "5.1.2"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.10.1
+version: 3.11.0

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
           - key: bosco.cert
             path: bosco.cert
             mode: 0o400
-      {{ end }
+      {{ end }}
       {{ if .Values.HostCredentials.HostCertKeySecret }}
       - name: osg-hosted-ce-hostcertkey-volume
         secret:

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -59,6 +59,15 @@ spec:
           - key: bosco.key
             path: bosco.key
             mode: 256
+      {{ if .Values.RemoteCluster.SSHCertificateSecret }}
+      - name: bosco-ssh-cert-volume
+        secret:
+          secretName: {{ .Values.RemoteCluster.SSHCertificateSecret }}
+          items:
+          - key: bosco.cert
+            path: bosco.cert
+            mode: 0o400
+      {{ end }
       {{ if .Values.HostCredentials.HostCertKeySecret }}
       - name: osg-hosted-ce-hostcertkey-volume
         secret:
@@ -160,6 +169,11 @@ spec:
         - name: bosco-ssh-private-key-volume
           mountPath: /etc/osg/bosco.key
           subPath: bosco.key
+        {{ if .Values.RemoteCluster.SSHCertificateSecret }}
+        - name: bosco-ssh-cert-volume
+          mountPath: /etc/osg/bosco.cert
+          subPath: bosco.cert
+        {{ end }}
         - name: osg-hosted-ce-{{ .Values.Instance }}-htcondor-ce-configuration
           mountPath: /etc/condor-ce/config.d/99-instance.conf
           subPath: 99-instance.conf

--- a/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -18,6 +18,9 @@ RemoteCluster:
   LoginHost: remote-ssh.login.org
   # SLATE secret with 'bosco.key' containing the SSH key to access LoginHost:
   PrivateKeySecret: lincolnb-bosco
+  # Secret containing a signed certificate (required by some sites)
+  # See CertificateFile in `man ssh_config`
+  SSHCertificateSecret: null
   # condor, slurm, pbs, sge, or lsf
   Batch: slurm
   MemoryPerNode: 1024


### PR DESCRIPTION
Needs https://github.com/opensciencegrid/docker-compute-entrypoint/pull/49 to do anything useful but should be safe without it