### PR TITLE
Place the SSH cert in the expected default location (SOFTWARE-4850)

### DIFF
--- a/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "5.1.2"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.11.0
+version: 3.11.1

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -171,7 +171,7 @@ spec:
           subPath: bosco.key
         {{ if .Values.RemoteCluster.SSHCertificateSecret }}
         - name: bosco-ssh-cert-volume
-          mountPath: /etc/osg/bosco.cert
+          mountPath: /etc/osg/bosco.key-cert.pub
           subPath: bosco.cert
         {{ end }}
         - name: osg-hosted-ce-{{ .Values.Instance }}-htcondor-ce-configuration


### PR DESCRIPTION
From `man ssh_config`:

> If no certificates have been explicitly specified by
> CertificateFile, ssh(1) will try to load certificate information from
> the filename obtained by appending -cert.pub to the path of a
> specified IdentityFile.

And many SSH tools appear to only look for the cert in this default location