### PR TITLE
Add the ability to predefine known_hosts (SOFTWARE-4896)

### DIFF
--- a/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "5.1.2"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.12.0
+version: 3.13.0

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -193,3 +193,17 @@ data:
     exec nginx -g 'daemon off;'
 
 {{ end }}
+{{ if .Values.RemoteCluster.KnownHosts}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: osg-hosted-ce-{{ .Values.Instance }}-known-hosts
+  labels:
+    app: osg-hosted-ce
+    instance: {{ .Values.Instance }}
+    release: {{ .Release.Name }}
+data:
+  ssh_known_hosts: |+
+    {{ .Values.RemoteCluster.KnownHosts }}
+{{ end }}

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -68,6 +68,10 @@ spec:
             path: bosco.cert
             mode: 0o400
       {{ end }}
+      {{ if .Values.RemoteCluster.KnownHosts }}
+      - name: ssh-known-hosts
+        configMap: osg-hosted-ce-{{ .Values.Instance }}-known-hosts
+      {{ end }}
       {{ if .Values.HostCredentials.HostCertKeySecret }}
       - name: osg-hosted-ce-hostcertkey-volume
         secret:
@@ -173,6 +177,11 @@ spec:
         - name: bosco-ssh-cert-volume
           mountPath: /etc/osg/bosco.key-cert.pub
           subPath: bosco.cert
+        {{ end }}
+        {{ if .Values.RemoteCluster.KnownHosts }}
+        - name: ssh-known-hosts
+          mountPath: /etc/osg/ssh_known_hosts
+          subPath: ssh_known_hosts
         {{ end }}
         - name: osg-hosted-ce-{{ .Values.Instance }}-htcondor-ce-configuration
           mountPath: /etc/condor-ce/config.d/99-instance.conf

--- a/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -14,11 +14,20 @@ Topology:
   Production: true
 
 RemoteCluster:
-  # SSH host
+  # Target SSH login host (host where batch system binaries are installed)
   LoginHost: remote-ssh.login.org
-  # One or more jump proxies as either [user@]host[:port] or an ssh URI.
-  # See ProxyJump in 'man ssh_config'
+  # One or more jump proxies as either [user@]host[:port] or an ssh
+  # URI (see ProxyJump in 'man ssh_config').
+  # If set, KnownHosts below must also be set.
   ProxyJump: null
+  # Contents of SSH known_hosts
+  # Required for sites with ProyJump defined
+  KnownHosts: null
+  # Example:
+  # KnownHosts: |+
+  #    login04.osgconnect.net ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqsciY/FmcH6yedW7DxbTwLjkwlgVcbcG43QwdaSvMuN5EHAeLRH2P6ig3H6s/4hZqJn7AU2oNsoIqjZZ8iHqGyiTB9r70Aovt9PUuQXw5qHvYiIoyw49/waJ+yzu4+UD3qfnxeHuRw5EOaXia72MNJJ4lBMoS6iw1JveFJY4rBgKZ7nta1eAGGfHADsf5lfhlIXnJPN050X6zcUjqEEKXjdUkFa3wDiVbFEIESCMwi1b6Q1OXGGFwuSNse1X38CREBzQ+NjOB97o70chZoh2jZ2O3iZZZbujYcDzpxF3RxmewFC3pDmkoOpJrfV2W58n1KdJJnyvjlqEZGXCXcAlB
+  #    login04.osgconnect.net ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCnySArMSVd0O3UniYN4vX3a/d9d9mEMnrf2z1S900t0GrxVazVGu3ObeLfWwYRc3qFXNRPGh3mKcz5QVG6gcm4=
+  #    login04.osgconnect.net ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJBW6weAaFSdLYksn4vIvqt4+geNVQ/bUvp71kTeQsKV
   # SLATE secret with 'bosco.key' containing the SSH key to access LoginHost:
   PrivateKeySecret: lincolnb-bosco
   # Secret containing a signed certificate (required by some sites)


### PR DESCRIPTION
The `hosted-ce` container takes `/etc/osg/ssh_known_hosts` and dumps it into the appropriate locations: https://github.com/opensciencegrid/docker-compute-entrypoint/pull/53