### PR TITLE
Squid to use OSG Hub

### DIFF
--- a/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
@@ -5,4 +5,4 @@ appVersion: 4.13-1.1
 description: A Helm chart for configuration and deployment of the Open Science Grid's Frontier Squid application.
 name: osg-frontier-squid
 # Chart version
-version: 1.7.6
+version: 1.7.7

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
       containers:
       # Container for the primary application, OSG Frontier Squid
       - name: osg-frontier-squid
-        image: "opensciencegrid/frontier-squid:{{ .Values.ImageTag | default "release" }}"
+        image: "hub.opensciencegrid.org/opensciencegrid/frontier-squid:{{ .Values.ImageTag | default "release" }}"
         imagePullPolicy: Always
         env:
         - name: SQUID_IPRANGE


### PR DESCRIPTION
We have changed the OSG Frontier Squid application to use the OSG Harbor Instance (aka OSG Hub) 