### PR TITLE
Collapse multi-CPU options down to a single parameter

### DIFF
--- a/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
@@ -5,4 +5,4 @@ appVersion: 4.13-1.1
 description: A Helm chart for configuration and deployment of the Open Science Grid's Frontier Squid application.
 name: osg-frontier-squid
 # Chart version
-version: 1.7.7
+version: 1.7.12

--- a/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
@@ -5,4 +5,4 @@ appVersion: 4.13-1.1
 description: A Helm chart for configuration and deployment of the Open Science Grid's Frontier Squid application.
 name: osg-frontier-squid
 # Chart version
-version: 1.7.12
+version: 1.8.0

--- a/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
@@ -5,4 +5,4 @@ appVersion: 4.13-1.1
 description: A Helm chart for configuration and deployment of the Open Science Grid's Frontier Squid application.
 name: osg-frontier-squid
 # Chart version
-version: 1.8.0
+version: 1.8.1

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/configmap.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/configmap.yaml
@@ -17,10 +17,9 @@ data:
     setoptionparameter("acl RESTRICT_DEST", 3, "{{ .Values.SquidConf.RESTRICT_DEST }}")
     uncomment("http_access deny !RESTRICT_DEST")
     {{- end }}
-    {{- if .Values.SquidConf.Cpu_Affinity_Map }}
     # Set the CPU affinity map
-    setoption("cpu_affinity_map", "{{ .Values.SquidConf.Cpu_Affinity_Map }}")
-    {{- end }}
+    {{ $AffinityMap := untilStep 1 (int (add1 .Values.SquidConf.CPU )) 1 | join "," }}
+    setoption("cpu_affinity_map", "process_numbers={{ $AffinityMap }} cores={{ $AffinityMap }}")
     {{- if .Values.SquidConf.Logfile_Rotate }}
     # Whether to rotate logs or not
     setoption("logfile_rotate", "{{ .Values.SquidConf.Logfile_Rotate }}")
@@ -29,7 +28,7 @@ data:
     # Allow the user to set the maximum object size in memory
     setoption("maximum_object_size_in_memory", "{{ .Values.SquidConf.MaximumObjectSizeInMemory }} KB")
     {{ end }}
-    {{- if .Values.SquidConf.Workers }}
+    {{- if .Values.SquidConf.CPU }}
     # If multiple workers are requested
     {{- if .Values.SquidConf.DisableLogging }}
     # If multiple workers are used, and logging is disabled:
@@ -39,7 +38,7 @@ data:
     setoptionparameter("logformat awstats", 3, "kid${process_number}")
     {{ end }}
     # Set the number of workers and create a cache for each unique worker
-    setoption("workers", {{ .Values.SquidConf.Workers }} )
+    setoption("workers", {{ .Values.SquidConf.CPU }} )
     setoption("cache_dir", "ufs /var/cache/squid/squid${process_number} {{ .Values.SquidConf.CacheSize }} 16 256")
     {{ else }}
     # If multiple workers are NOT requested, set a single cache dir with one of

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/configmap.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/configmap.yaml
@@ -17,9 +17,11 @@ data:
     setoptionparameter("acl RESTRICT_DEST", 3, "{{ .Values.SquidConf.RESTRICT_DEST }}")
     uncomment("http_access deny !RESTRICT_DEST")
     {{- end }}
+    {{- if .Values.SquidConf.CPU }} 
     # Set the CPU affinity map
     {{ $AffinityMap := untilStep 1 (int (add1 .Values.SquidConf.CPU )) 1 | join "," }}
     setoption("cpu_affinity_map", "process_numbers={{ $AffinityMap }} cores={{ $AffinityMap }}")
+    {{ end }}
     {{- if .Values.SquidConf.Logfile_Rotate }}
     # Whether to rotate logs or not
     setoption("logfile_rotate", "{{ .Values.SquidConf.Logfile_Rotate }}")
@@ -38,7 +40,11 @@ data:
     setoptionparameter("logformat awstats", 3, "kid${process_number}")
     {{ end }}
     # Set the number of workers and create a cache for each unique worker
+    {{- if .Values.SquidConf.CPU }}
     setoption("workers", {{ .Values.SquidConf.CPU }} )
+    {{ else }}
+    setoption("workers", "1" )
+    {{ end }}
     setoption("cache_dir", "ufs /var/cache/squid/squid${process_number} {{ .Values.SquidConf.CacheSize }} 16 256")
     {{ else }}
     # If multiple workers are NOT requested, set a single cache dir with one of

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/configmap.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/configmap.yaml
@@ -147,10 +147,37 @@ data:
     instance=$1
     host=$2
     site=$3
+
+    if [[ -z $AAAS_SERVER ]]; then
+       AAAS_SERVER="aaas.atlas-ml.org"
+    fi
     
     
     echo $instance $host $site
-    curl --request POST "https://aaas.atlas-ml.org/alarm" \
+    curl --request POST "https://${AAAS_SERVER}/alarm" \
          -k \
          --header 'Content-Type: application/json' \
          --data-raw '{ "category" : "SLATE", "subcategory": "Squid", "event": "server down", "tags":"'"$site"'", "body":"down", "source": {"site": "'"$site"'", "instance": "'"$instance"'", "host": "'"$host"'"} }'
+  heartbeat.sh: |+
+    #!/bin/bash
+    usage () {
+        echo "$0 <instance> <site>"
+        echo "   <instance> is SLATE instance ID."
+        echo "   <site> is SLATE site name."
+    }
+    
+    if [ $# -lt 2 ]; then
+        usage
+        exit 1
+    fi
+    
+    if [[ -z $AAAS_SERVER ]]; then
+       AAAS_SERVER="aaas.atlas-ml.org"
+    fi
+
+    instance=$1
+    site=$2
+    curl --request POST "https://${AAAS_SERVER}/heartbeat/" \
+         --header 'Content-Type: application/json' \
+         --data-raw '{"category": "SLATE", "subcategory": "Squid", "event": "liveness", "tags": "'"$site"'", "source": { "site": "'"$site"'", "instance" : "'"$instance"'"}}'
+    echo "Sent heartbeat to $AAAS_SERVER for instance $instance at site $site" >> /var/log/aaas-heartbeat.log

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
@@ -55,7 +55,11 @@ spec:
         {{ end }}
         resources:
           requests:
+            {{ if .Values.SquidConf.CPU }}
             cpu: {{ .Values.SquidConf.CPU }}
+            {{ else }} 
+            cpu: 1
+            {{ end }}
         {{ if not  .Values.SquidConf.CacheDirOnHost }}
 # converting CacheSize to MiB and adding it to total request
             ephemeral-storage: {{ add .Values.SquidConf.RequestEphemeralSize  (floor (div (mul .Values.SquidConf.CacheSize 9537) 10000))  }}Mi

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
@@ -49,6 +49,10 @@ spec:
         - name: SQUID_MAX_ACCESS_LOG
           value: {{ .Values.SquidConf.MaxAccessLog }}
         {{ end }} 
+        {{ if .Values.Alarm.AaasServer }}
+        - name: AAAS_SERVER
+          value: '{{ .Values.Alarm.AaasServer }}'
+        {{ end }}
         resources:
           requests:
             cpu: {{ .Values.SquidConf.CPU }}
@@ -73,6 +77,11 @@ spec:
           hostPort: 3401
           {{ end }}
         {{ if and .Values.NodeSelection.Hostname .Values.Alarm.Site }}
+        livenessProbe:
+          exec:
+            command: ["/bin/sh","-c","/usr/local/sbin/heartbeat.sh {{ .Values.Instance }} {{ .Values.Alarm.Site }}"]
+          initialDelaySeconds: 10
+          periodSeconds: 10
         lifecycle:
           preStop:
             exec:
@@ -117,6 +126,9 @@ spec:
         - name: osg-frontier-squid-{{ .Values.Instance }}-conf
           mountPath: /usr/local/sbin/squid-pre-stop-alarm.sh
           subPath: squid-pre-stop-alarm.sh 
+        - name: osg-frontier-squid-{{ .Values.Instance }}-conf
+          mountPath: /usr/local/sbin/heartbeat.sh
+          subPath: heartbeat.sh
         {{ end }}
       volumes:
         {{ if .Values.SquidConf.CacheDirOnHost }}
@@ -150,6 +162,9 @@ spec:
             {{ if and .Values.NodeSelection.Hostname .Values.Alarm.Site }}
             - key: squid-pre-stop-alarm.sh
               path: squid-pre-stop-alarm.sh
+              mode: 448
+            - key: heartbeat.sh
+              path: heartbeat.sh
               mode: 448
             {{ end }}
         - name: osg-frontier-squid-{{ .Values.Instance }}-data

--- a/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
@@ -49,8 +49,10 @@ Service:
   #MonitoringNodePort: 31201
 
 SquidConf:
-  # The number of CPU cores allocated to the Squid application. The default is 2.
-  CPU: 1
+  # The number of CPU cores allocated to the Squid application. If not
+  # specified, the default is 1. You only need to uncomment this field if you
+  # plan to use more than 1 CPU for Squid.
+  # CPU: 1
   # The amount of memory (in MB) that Frontier Squid may use on the machine.
   # Per Frontier Squid, do not consume more than 1/8 of system memory with Frontier Squid
   CacheMem: 4096

--- a/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
@@ -50,7 +50,7 @@ Service:
 
 SquidConf:
   # The number of CPU cores allocated to the Squid application. The default is 2.
-  CPU: 2
+  CPU: 1
   # The amount of memory (in MB) that Frontier Squid may use on the machine.
   # Per Frontier Squid, do not consume more than 1/8 of system memory with Frontier Squid
   CacheMem: 4096
@@ -94,11 +94,6 @@ SquidConf:
   #DisableLogging: False
   # truncates log file every 2 minutes.
   CleanLog: False
-  # Set this if you want to run more than one cache process concurrently.
-  # Cache memory/disk space is not shared; values configured above are per process. 
-  #Workers: 4
-  # This setting can be used to pin cache processes to CPU cores
-  #Cpu_Affinity_Map: "process_numbers=1,2,3,4 cores=2,3,4,5"
   # Configure the number of names to use when rotating logfiles
   Logfile_Rotate: "30"
   # Set the max size for the access log file

--- a/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/values.yaml
@@ -123,11 +123,15 @@ NodeSelection:
   OpenDefaultMonPort: False
 
 #Allow the frontier-squid instance to send an alert before container stops.
-#The alert will be sent to  https://aaas.atlas-ml.org/ and those who subscribed to the alert category will get notified. 
+#The alert will be sent to the configured value for AaasServer, by default
+#"aaas.atlas-ml.org", and those who subscribed to the alert category will get
+#notified. 
 #To enable the alarm feature, set the proper value for 'Site' below. 
-#Prerequists: The above Instance and NodeSelection.Hostname config variables need to be set to some proper values.
+#Prerequisites: The above Instance and NodeSelection.Hostname config variables
+#need to be set to some proper values.
 Alarm:
   Site: null
+  AaasServer: aaas.atlas-ml.org
 
 Pod:
   # Set to true if you want to use the host's timezone settings. This would affect the timestamps of log messages.


### PR DESCRIPTION
The proposed change uses Helm's templating language to collapse down multi-CPU options down into a single "CPU" option that will automatically set up the Squid child workers and pin them as appropriate.