### PR TITLE
Use built-in remote_gahp support for non-standard SSH port

### DIFF
--- a/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "5.1.3"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.16.0
+version: 3.16.1

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -76,8 +76,8 @@ data:
     [
     GridResource = "intentionally left blank";
     eval_set_GridResource = strcat("batch ", "{{ .Values.RemoteCluster.Batch }} ",
-                                   Owner, "@", "{{ .Values.RemoteCluster.LoginHost }} ",
-                                   "--rgahp-glite ", "~/{{ .Values.RemoteCluster.BoscoDir | default "~/bosco"}}/glite"
+                                   Owner, "@", "{{ .Values.RemoteCluster.LoginHost }}",
+                                   " --rgahp-glite ", "~/{{ .Values.RemoteCluster.BoscoDir | default "~/bosco"}}/glite"
                                    {{ if .Values.BoscoOverrides.TarballURL | default "" | contains "bosco-1.3"  }}
                                    , " --rgahp-script batch_gahp"
                                    {{ end }}

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -76,7 +76,7 @@ data:
     [
     GridResource = "intentionally left blank";
     eval_set_GridResource = strcat("batch ", "{{ .Values.RemoteCluster.Batch }} ",
-                                   Owner, "@", "{{ regexReplaceAllLiteral ":[0-9]*$" .Values.RemoteCluster.LoginHost "" }} ",
+                                   Owner, "@", "{{ .Values.RemoteCluster.LoginHost }} ",
                                    "--rgahp-glite ", "~/{{ .Values.RemoteCluster.BoscoDir | default "~/bosco"}}/glite"
                                    {{ if .Values.BoscoOverrides.TarballURL | default "" | contains "bosco-1.3"  }}
                                    , " --rgahp-script batch_gahp"


### PR DESCRIPTION
(SOFTWARE-5202)

The previous solution was to depend on the SSH config and drop the
port consideration. The remote_gahp now supports <FQDN>:<PORT> but
defaults to 22 if the port isn't specified