### PR TITLE
Cache memory is now aware of the CPUs requested

### DIFF
--- a/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
@@ -5,4 +5,4 @@ appVersion: 4.13-1.1
 description: A Helm chart for configuration and deployment of the Open Science Grid's Frontier Squid application.
 name: osg-frontier-squid
 # Chart version
-version: 1.8.1
+version: 1.8.2

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/configmap.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/configmap.yaml
@@ -74,7 +74,11 @@ data:
     {{ if .Values.SquidConf.MonitoringIPRange }}
     acl HOST_MONITOR src {{ .Values.SquidConf.MonitoringIPRange }}
     {{ end }}
+    {{- if .Values.SquidConf.CPU }} 
+    cache_mem {{ div .Values.SquidConf.CacheMem .Values.SquidConf.CPU }} MB
+    {{- else }}
     cache_mem {{ .Values.SquidConf.CacheMem }} MB
+    {{- end }}
     {{ if .Values.SquidConf.Workers }}
     workers {{ .Values.SquidConf.Workers }} # multiple worker case
     cache_dir ufs /var/cache/squid/squid${process_number} {{ .Values.SquidConf.CacheSize }} 16 256

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
@@ -40,7 +40,11 @@ spec:
         - name: SQUID_IPRANGE
           value: {{ .Values.SquidConf.IPRange }}
         - name: SQUID_CACHE_MEM
+        {{- if .Values.SquidConf.CPU }}
+          value: '{{ div .Values.SquidConf.CacheMem .Values.SquidConf.CPU }} MB'  
+        {{- else }} 
           value: '{{ .Values.SquidConf.CacheMem }} MB'  
+        {{- end }}
         {{ if .Values.SquidConf.CacheSize }}
         - name: SQUID_CACHE_DISK
           value: '{{ .Values.SquidConf.CacheSize }}'


### PR DESCRIPTION
The cache memory spec will now consider how many CPUs were requested and divide accordingly. Squid passes the `cache_mem` memory value to each child process it manages in multi-core mode. 

For some reason this has to happen in two places. Need to investigate if this is redundant or not.