### PR TITLE
Clean up cpu/disk requests, add mem requests

### DIFF
--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
@@ -64,17 +64,28 @@ spec:
             {{ else }} 
             cpu: 1
             {{ end }}
-        {{ if not  .Values.SquidConf.CacheDirOnHost }}
-# converting CacheSize to MiB and adding it to total request
+            {{ if .Values.SquidConf.CacheMem }}
+            memory: '{{ .Values.SquidConf.CacheMem }}Mi'
+            {{ end }} 
+            {{ if not  .Values.SquidConf.CacheDirOnHost }}
             ephemeral-storage: {{ add .Values.SquidConf.RequestEphemeralSize  (floor (div (mul .Values.SquidConf.CacheSize 9537) 10000))  }}Mi
-          limits:
-# converting CacheSize to MiB and adding it to total limit
-            ephemeral-storage: {{ add .Values.SquidConf.LimitEphemeralSize  (floor (div (mul .Values.SquidConf.CacheSize 9537) 10000))  }}Mi
-        {{ else }}
+            {{ else }}
             ephemeral-storage: {{ .Values.SquidConf.RequestEphemeralSize  }}Mi
+            {{ end }}
           limits:
+            {{ if .Values.SquidConf.CPU }}
+            cpu: {{ mul .Values.SquidConf.CPU 2 }}
+            {{ else }} 
+            cpu: 2
+            {{ end }}
+            {{ if .Values.SquidConf.CacheMem }}
+            memory: '{{ mul .Values.SquidConf.CacheMem 2 }}Mi'
+            {{ end }} 
+            {{ if not  .Values.SquidConf.CacheDirOnHost }}
+            ephemeral-storage: {{ add .Values.SquidConf.LimitEphemeralSize  (floor (div (mul .Values.SquidConf.CacheSize 9537) 10000))  }}Mi
+            {{ else }}
             ephemeral-storage: {{ .Values.SquidConf.LimitEphemeralSize  }}Mi
-        {{ end }}
+            {{ end }}
         ports:
         - containerPort: 3128
           name: squid

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
@@ -59,33 +59,33 @@ spec:
         {{ end }}
         resources:
           requests:
-            {{ if .Values.SquidConf.CPU }}
+            {{- if .Values.SquidConf.CPU }}
             cpu: {{ .Values.SquidConf.CPU }}
-            {{ else }} 
+            {{- else }} 
             cpu: 1
-            {{ end }}
-            {{ if .Values.SquidConf.CacheMem }}
+            {{- end }}
+            {{- if .Values.SquidConf.CacheMem }}
             memory: '{{ .Values.SquidConf.CacheMem }}Mi'
-            {{ end }} 
-            {{ if not  .Values.SquidConf.CacheDirOnHost }}
+            {{- end }} 
+            {{- if not  .Values.SquidConf.CacheDirOnHost }}
             ephemeral-storage: {{ add .Values.SquidConf.RequestEphemeralSize  (floor (div (mul .Values.SquidConf.CacheSize 9537) 10000))  }}Mi
-            {{ else }}
+            {{- else }}
             ephemeral-storage: {{ .Values.SquidConf.RequestEphemeralSize  }}Mi
-            {{ end }}
+            {{- end }}
           limits:
-            {{ if .Values.SquidConf.CPU }}
+            {{- if .Values.SquidConf.CPU }}
             cpu: {{ mul .Values.SquidConf.CPU 2 }}
-            {{ else }} 
+            {{- else }} 
             cpu: 2
-            {{ end }}
-            {{ if .Values.SquidConf.CacheMem }}
+            {{- end }}
+            {{- if .Values.SquidConf.CacheMem }}
             memory: '{{ mul .Values.SquidConf.CacheMem 2 }}Mi'
-            {{ end }} 
-            {{ if not  .Values.SquidConf.CacheDirOnHost }}
+            {{- end }} 
+            {{- if not  .Values.SquidConf.CacheDirOnHost }}
             ephemeral-storage: {{ add .Values.SquidConf.LimitEphemeralSize  (floor (div (mul .Values.SquidConf.CacheSize 9537) 10000))  }}Mi
-            {{ else }}
+            {{- else }}
             ephemeral-storage: {{ .Values.SquidConf.LimitEphemeralSize  }}Mi
-            {{ end }}
+            {{- end }}
         ports:
         - containerPort: 3128
           name: squid


### PR DESCRIPTION
We were not previously requesting/limiting memory usage. We see on some squids that they exit with Error 137, which is evidently OOM according to the internet.

I've tested this with the default values.yaml and I see:
```yaml
        resources:
          requests:
            cpu: 1
            memory: '4096Mi'
            ephemeral-storage: 16537Mi
          limits:
            cpu: 2
            memory: '8192Mi'
            ephemeral-storage: 21537Mi
```

If I render the template with `CacheDirOnHost: True`, I get:
``` yaml   
        resources:
          requests:
            cpu: 1
            memory: '4096Mi'
            ephemeral-storage: 7000Mi
          limits:
            cpu: 2
            memory: '8192Mi'
            ephemeral-storage: 12000Mi
```

So I think things are ~working as expected, since we add an additional bit of extra disk  for the cache itself on top of the ephemeral storage request if CacheDirOnHost is false (default), and go with only the values specified in values.yaml if the CacheDirOnHost is true (no additional disk needed).