### PR TITLE
Replace the liveness probe with a cron. 

### DIFF
--- a/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
@@ -5,4 +5,4 @@ appVersion: 4.13-1.1
 description: A Helm chart for configuration and deployment of the Open Science Grid's Frontier Squid application.
 name: osg-frontier-squid
 # Chart version
-version: 1.8.3
+version: 1.8.4

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/configmap.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/configmap.yaml
@@ -190,3 +190,7 @@ data:
          --header 'Content-Type: application/json' \
          --data-raw '{"category": "SLATE", "subcategory": "Squid", "event": "liveness", "tags": "'"$site"'", "source": { "site": "'"$site"'", "instance" : "'"$instance"'"}}'
     echo "Sent heartbeat to $AAAS_SERVER for instance $instance at site $site" >> /var/log/aaas-heartbeat.log
+  {{- if .Values.Alarm.Site }}
+  heartbeat.cron: |+
+    * * * * * squid /usr/local/sbin/heartbeat.sh {{ .Values.Instance }} {{ quote .Values.Alarm.Site }}
+  {{- end }}

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
@@ -96,11 +96,6 @@ spec:
           hostPort: 3401
           {{ end }}
         {{ if and .Values.NodeSelection.Hostname .Values.Alarm.Site }}
-        livenessProbe:
-          exec:
-            command: ["/bin/sh","-c","/usr/local/sbin/heartbeat.sh {{ .Values.Instance }} {{ .Values.Alarm.Site }}"]
-          initialDelaySeconds: 10
-          periodSeconds: 10
         lifecycle:
           preStop:
             exec:
@@ -148,6 +143,9 @@ spec:
         - name: osg-frontier-squid-{{ .Values.Instance }}-conf
           mountPath: /usr/local/sbin/heartbeat.sh
           subPath: heartbeat.sh
+        - name: osg-frontier-squid-{{ .Values.Instance }}-conf
+          mountPath: /etc/cron.d/heartbeat.cron
+          subPath: heartbeat.cron
         {{ end }}
       volumes:
         {{ if .Values.SquidConf.CacheDirOnHost }}
@@ -185,6 +183,9 @@ spec:
             - key: heartbeat.sh
               path: heartbeat.sh
               mode: 448
+            - key: heartbeat.cron
+              path: heartbeat.cron
+              mode: 420
             {{ end }}
         - name: osg-frontier-squid-{{ .Values.Instance }}-data
         {{ if .Values.SLATE.LocalStorage }}


### PR DESCRIPTION
Sometimes, for whatever reason, the Heartbeat liveness probe will fail. This isn't because Squid has failed, necessarily - just that the heartbeat script can't reach the other side. Replace the liveness probe with a cron- we don't want to depend on the availability of a remote server in order for Squid to run. Having it be a cron makes the probe more passive. 