### PR TITLE
Fix Squid heartbeat script mode

### DIFF
--- a/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
@@ -5,4 +5,4 @@ appVersion: 4.13-1.1
 description: A Helm chart for configuration and deployment of the Open Science Grid's Frontier Squid application.
 name: osg-frontier-squid
 # Chart version
-version: 1.8.4
+version: 1.8.5

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
@@ -182,7 +182,7 @@ spec:
               mode: 448
             - key: heartbeat.sh
               path: heartbeat.sh
-              mode: 448
+              mode: 493
             - key: heartbeat.cron
               path: heartbeat.cron
               mode: 420


### PR DESCRIPTION
`heartbeat.sh` is currently showing as mode 700 but we need it to be 755 to be executed by the squid user. 