### PR TITLE
(not urgent) Formatting pass

### DIFF
--- a/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/Chart.yaml
@@ -5,4 +5,4 @@ appVersion: 4.13-1.1
 description: A Helm chart for configuration and deployment of the Open Science Grid's Frontier Squid application.
 name: osg-frontier-squid
 # Chart version
-version: 1.8.5
+version: 1.8.6

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/configmap.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/configmap.yaml
@@ -21,7 +21,7 @@ data:
     # Set the CPU affinity map
     {{ $AffinityMap := untilStep 1 (int (add1 .Values.SquidConf.CPU )) 1 | join "," }}
     setoption("cpu_affinity_map", "process_numbers={{ $AffinityMap }} cores={{ $AffinityMap }}")
-    {{ end }}
+    {{- end }}
     {{- if .Values.SquidConf.Logfile_Rotate }}
     # Whether to rotate logs or not
     setoption("logfile_rotate", "{{ .Values.SquidConf.Logfile_Rotate }}")
@@ -29,7 +29,7 @@ data:
     {{- if .Values.SquidConf.MaximumObjectSizeInMemory }}
     # Allow the user to set the maximum object size in memory
     setoption("maximum_object_size_in_memory", "{{ .Values.SquidConf.MaximumObjectSizeInMemory }} KB")
-    {{ end }}
+    {{- end }}
     {{- if .Values.SquidConf.CPU }}
     # If multiple workers are requested
     {{- if .Values.SquidConf.DisableLogging }}
@@ -42,30 +42,31 @@ data:
     # Set the number of workers and create a cache for each unique worker
     {{- if .Values.SquidConf.CPU }}
     setoption("workers", {{ .Values.SquidConf.CPU }} )
-    {{ else }}
+    {{- else }}
     setoption("workers", "1" )
-    {{ end }}
+    {{- end }}
     setoption("cache_dir", "ufs /var/cache/squid/squid${process_number} {{ .Values.SquidConf.CacheSize }} 16 256")
-    {{ else }}
+    {{- else }}
     # If multiple workers are NOT requested, set a single cache dir with one of
     # three options: 
     #  1. Cache with a minimum object size OR
     #  2. Cache with the disk cache disabled entirely OR
     #  3. Cache with no special parameters (default).
-    {{ if .Values.SquidConf.DiskCacheMinObjSize }}
+    {{- if .Values.SquidConf.DiskCacheMinObjSize }}
     setoption("cache_dir", "ufs /var/cache/squid/squid {{ .Values.SquidConf.CacheSize }} 16 256 min_size={{ .Values.SquidConf.DiskCacheMinObjSize }}")
-    {{ else if .Values.SquidConf.DisableDiskCache }}
+    {{- else if .Values.SquidConf.DisableDiskCache }}
     setoptionparameter("cache_dir", 1, "null")
-    {{ else }}
+    {{- else }}
     setoption("cache_dir", "ufs /var/cache/squid/squid {{ .Values.SquidConf.CacheSize }} 16 256")
-    {{ end }} 
+    {{- end }} 
     {{- if .Values.SquidConf.DisableLogging }}
     # Let the user enable/disable logging for a single worker case
     setoption("access_log", "none")
     {{- end }}
-    {{ end }}
-# The below 60-image-post-init.sh script is not mounted and the above new script takes care of the customization needed
-# 2-3 setttings are done vai env vars as per the OSG docs
+    {{- end }}
+  # The below 60-image-post-init.sh script is not mounted and the above new
+  # script takes care of the customization needed 2-3 setttings are done vai
+  # env vars as per the OSG docs
   60-image-post-init.sh: |+
     echo "Generating squid.conf..."
     grep -v cache_dir /etc/squid/squid.conf.frontierdefault > /etc/squid/squid.conf
@@ -73,26 +74,26 @@ data:
     acl NET_LOCAL src {{ .Values.SquidConf.IPRange }}
     {{ if .Values.SquidConf.MonitoringIPRange }}
     acl HOST_MONITOR src {{ .Values.SquidConf.MonitoringIPRange }}
-    {{ end }}
+    {{- end }}
     {{- if .Values.SquidConf.CPU }} 
     cache_mem {{ div .Values.SquidConf.CacheMem .Values.SquidConf.CPU }} MB
     {{- else }}
     cache_mem {{ .Values.SquidConf.CacheMem }} MB
     {{- end }}
-    {{ if .Values.SquidConf.Workers }}
+    {{- if .Values.SquidConf.Workers }}
     workers {{ .Values.SquidConf.Workers }} # multiple worker case
     cache_dir ufs /var/cache/squid/squid${process_number} {{ .Values.SquidConf.CacheSize }} 16 256
     logformat awstats %>a kid${process_number} %un [%{%d/%b/%Y:%H:%M:%S}tl.%03tu %{%z}tl] "%rm %ru HTTP/%rv" %>Hs %<st %Ss:%Sh %tr "%{X-Frontier-Id}>h %{cvmfs-info}>h" "%{Referer}>h" "%{User-Agent}>h"
     visible_hostname '`uname -n`'/${process_number}
-    {{ else }} # single worker case
+    {{- else }} # single worker case
     cache_dir ufs /var/cache/squid {{ .Values.SquidConf.CacheSize }} 16 256
-    {{ end }}
-    {{ if .Values.SquidConf.Cpu_Affinity_Map }}
+    {{- end }}
+    {{- if .Values.SquidConf.Cpu_Affinity_Map }}
     cpu_affinity_map {{ .Values.SquidConf.Cpu_Affinity_Map }}
-    {{ end }}
-    {{ if .Values.SquidConf.Logfile_Rotate }}
+    {{- end }}
+    {{- if .Values.SquidConf.Logfile_Rotate }}
     logfile_rotate {{ .Values.SquidConf.Logfile_Rotate }}
-    {{ end }}
+    {{- end }}
     acl URN proto URN
     http_access deny URN
     ' >> /etc/squid/squid.conf
@@ -109,14 +110,14 @@ data:
       done
     fi
     rm -f /dev/shm/squid-*.shm
-    {{ else }}
+    {{- else }}
     if [[ ! -d /var/cache/squid/00 ]]; then
         echo "Initializing cache..."
         /usr/sbin/squid -N -f /etc/squid/squid.conf -z
     fi
-    {{ end }}
+    {{- end }}
     echo "End of custom 60-image-post-init.sh"
-{{ if .Values.SquidConf.LogToStdout }}
+{{- if .Values.SquidConf.LogToStdout }}
   # Inject an extra helper to copy the squid logs to supervisor's stdout, 
   # where Docker can capture them. 
   50-squid-log-dump.conf: |+
@@ -126,8 +127,8 @@ data:
     autorestart=true
     stdout_logfile=/dev/stdout
     stdout_logfile_maxbytes=0
-{{ end }}
-{{ if .Values.SquidConf.CleanLog }}
+{{- end }}
+{{- if .Values.SquidConf.CleanLog }}
   # Truncates log file every 2 min 
   55-squid-log-clean.conf: |+
     [program:squid-log-trunc]
@@ -136,7 +137,7 @@ data:
     autorestart=true
     stdout_logfile=/dev/stdout
     stdout_logfile_maxbytes=0
-{{ end }}
+{{- end }}
   squid-pre-stop-alarm.sh: |+
     #!/bin/sh
     

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/deployment.yaml
@@ -24,13 +24,13 @@ spec:
     spec:
       nodeSelector:
         # Required affinity for using local storage
-        {{ if .Values.SLATE.LocalStorage }}
+        {{- if .Values.SLATE.LocalStorage }}
         storage: "local"
-        {{ end }}
+        {{- end }}
         # For Node Selection
-        {{ if .Values.NodeSelection.Hostname }}
+        {{- if .Values.NodeSelection.Hostname }}
         kubernetes.io/hostname: {{ .Values.NodeSelection.Hostname }}
-        {{ end }}
+        {{- end }}
       containers:
       # Container for the primary application, OSG Frontier Squid
       - name: osg-frontier-squid
@@ -45,18 +45,18 @@ spec:
         {{- else }} 
           value: '{{ .Values.SquidConf.CacheMem }} MB'  
         {{- end }}
-        {{ if .Values.SquidConf.CacheSize }}
+        {{- if .Values.SquidConf.CacheSize }}
         - name: SQUID_CACHE_DISK
           value: '{{ .Values.SquidConf.CacheSize }}'
-        {{ end }}
-        {{ if .Values.SquidConf.MaxAccessLog }}
+        {{- end }}
+        {{- if .Values.SquidConf.MaxAccessLog }}
         - name: SQUID_MAX_ACCESS_LOG
           value: {{ .Values.SquidConf.MaxAccessLog }}
-        {{ end }} 
-        {{ if .Values.Alarm.AaasServer }}
+        {{- end }} 
+        {{- if .Values.Alarm.AaasServer }}
         - name: AAAS_SERVER
           value: '{{ .Values.Alarm.AaasServer }}'
-        {{ end }}
+        {{- end }}
         resources:
           requests:
             {{- if .Values.SquidConf.CPU }}
@@ -92,51 +92,52 @@ spec:
         - containerPort: 3401
           name: monitoring
           protocol: UDP
-          {{ if and .Values.NodeSelection.Hostname .Values.NodeSelection.OpenDefaultMonPort }}
+          {{- if and .Values.NodeSelection.Hostname .Values.NodeSelection.OpenDefaultMonPort }}
           hostPort: 3401
-          {{ end }}
-        {{ if and .Values.NodeSelection.Hostname .Values.Alarm.Site }}
+          {{- end }}
+        {{- if and .Values.NodeSelection.Hostname .Values.Alarm.Site }}
         lifecycle:
           preStop:
             exec:
               command: ["/bin/sh","-c","/usr/local/sbin/squid-pre-stop-alarm.sh {{ .Values.Instance }} {{ .Values.NodeSelection.Hostname }} {{ .Values.Alarm.Site }}"]
-        {{ end }}
+        {{- end }}
         volumeMounts:
-# Commented out and will probably not be needed. We're using the default 60-image-post-init.sh script 
-# that comes with upstream image. Our custom config has been moved to the .awk file added through configmap
+#       Commented out and will probably not be needed. We're using the default
+#       60-image-post-init.sh script that comes with upstream image. Our custom
+#       config has been moved to the .awk file added through configmap
 #        - name: osg-frontier-squid-{{ .Values.Instance }}-conf
 #          mountPath: /etc/osg/image-config.d/60-image-post-init.sh
 #          subPath: 60-image-post-init.sh 
-        {{ if .Values.SquidConf.CacheDirOnHost }}
+        {{- if .Values.SquidConf.CacheDirOnHost }}
         - name: osg-frontier-squid-{{ .Values.Instance }}-cachedir
           mountPath: /var/cache/squid 
-        {{ else if .Values.SLATE.LocalStorage }}
+        {{- else if .Values.SLATE.LocalStorage }}
         - mountPath: /var/cache/squid
           name: osg-frontier-squid-{{ .Values.Instance }}-data
-        {{ end }} 
-        {{ if .Values.SquidConf.LogToStdout }}
+        {{- end }} 
+        {{- if .Values.SquidConf.LogToStdout }}
         - name: osg-frontier-squid-{{ .Values.Instance }}-conf
           mountPath: /etc/supervisord.d/50-squid-log-dump.conf
           subPath: 50-squid-log-dump.conf 
-        {{ end }}
-        {{ if .Values.SquidConf.CleanLog }}
+        {{- end }}
+        {{- if .Values.SquidConf.CleanLog }}
         - name: osg-frontier-squid-{{ .Values.Instance }}-conf
           mountPath: /etc/supervisord.d/55-squid-log-clean.conf
           subPath: 55-squid-log-clean.conf 
-        {{ end }}
+        {{- end }}
         - mountPath: /etc/squid/customize.d/60-customization.awk
           subPath: 60-customization.awk
           name: osg-frontier-squid-{{ .Values.Instance }}-awk
-        {{ if .Values.Pod.UseHostTimezone }}
+        {{- if .Values.Pod.UseHostTimezone }}
         - name: tz
           mountPath: /etc/localtime
           readOnly: true
-        {{ end }}
-        {{ if and .Values.SquidConf.UseHostpathLogDir .Values.NodeSelection.Hostname }}
+        {{- end }}
+        {{- if and .Values.SquidConf.UseHostpathLogDir .Values.NodeSelection.Hostname }}
         - name: squid-log-dir
           mountPath: /var/log/squid
-        {{ end }}
-        {{ if and .Values.NodeSelection.Hostname .Values.Alarm.Site }}
+        {{- end }}
+        {{- if and .Values.NodeSelection.Hostname .Values.Alarm.Site }}
         - name: osg-frontier-squid-{{ .Values.Instance }}-conf
           mountPath: /usr/local/sbin/squid-pre-stop-alarm.sh
           subPath: squid-pre-stop-alarm.sh 
@@ -146,14 +147,14 @@ spec:
         - name: osg-frontier-squid-{{ .Values.Instance }}-conf
           mountPath: /etc/cron.d/heartbeat.cron
           subPath: heartbeat.cron
-        {{ end }}
+        {{- end }}
       volumes:
-        {{ if .Values.SquidConf.CacheDirOnHost }}
+        {{- if .Values.SquidConf.CacheDirOnHost }}
         - name: osg-frontier-squid-{{ .Values.Instance }}-cachedir
           hostPath:
             path: /var/cache/squid
             type: Directory
-        {{ end }} 
+        {{- end }} 
         - name: osg-frontier-squid-{{ .Values.Instance }}-awk
           configMap:
             name: {{ template "osg-frontier-squid.fullname" . }}
@@ -168,15 +169,15 @@ spec:
             - key: 60-image-post-init.sh
               path: 60-image-post-init.sh
               mode: 448
-            {{ if .Values.SquidConf.LogToStdout }}
+            {{- if .Values.SquidConf.LogToStdout }}
             - key: 50-squid-log-dump.conf
               path: 50-squid-log-dump.conf
-            {{ end }}
-            {{ if .Values.SquidConf.CleanLog }}
+            {{- end }}
+            {{- if .Values.SquidConf.CleanLog }}
             - key: 55-squid-log-clean.conf
               path: 55-squid-log-clean.conf
-            {{ end }}
-            {{ if and .Values.NodeSelection.Hostname .Values.Alarm.Site }}
+            {{- end }}
+            {{- if and .Values.NodeSelection.Hostname .Values.Alarm.Site }}
             - key: squid-pre-stop-alarm.sh
               path: squid-pre-stop-alarm.sh
               mode: 448
@@ -186,22 +187,22 @@ spec:
             - key: heartbeat.cron
               path: heartbeat.cron
               mode: 420
-            {{ end }}
+            {{- end }}
         - name: osg-frontier-squid-{{ .Values.Instance }}-data
-        {{ if .Values.SLATE.LocalStorage }}
+        {{- if .Values.SLATE.LocalStorage }}
           persistentVolumeClaim:
             claimName: osg-frontier-squid-{{ .Values.Instance }}-pvc
-        {{ else }}
+        {{- else }}
           emptyDir: {}
-        {{ end }}
-        {{ if .Values.Pod.UseHostTimezone }}
+        {{- end }}
+        {{- if .Values.Pod.UseHostTimezone }}
         - name: tz
           hostPath:
             path: /etc/localtime
-        {{ end }}
-        {{ if and .Values.SquidConf.UseHostpathLogDir .Values.NodeSelection.Hostname }}
+        {{- end }}
+        {{- if and .Values.SquidConf.UseHostpathLogDir .Values.NodeSelection.Hostname }}
         - name: squid-log-dir
           hostPath:
             path: /var/log/slate/hostPath/osg-frontier-squid
             type: Directory
-        {{ end }}
+        {{- end }}

--- a/stable/osg-frontier-squid/osg-frontier-squid/templates/service.yaml
+++ b/stable/osg-frontier-squid/osg-frontier-squid/templates/service.yaml
@@ -8,9 +8,9 @@ metadata:
     instance: {{ .Values.Instance | quote }}
 spec:
   type: {{ .Values.Service.ExternalVisibility }}
-  {{ if ne .Values.Service.ExternalVisibility "ClusterIP" }}
+  {{- if ne .Values.Service.ExternalVisibility "ClusterIP" }}
   externalTrafficPolicy: Local
-  {{ end }}
+  {{- end }}
   selector:
     app: {{ template "osg-frontier-squid.name" . }}
     release: {{ .Release.Name }}
@@ -19,17 +19,17 @@ spec:
   - port: {{ .Values.Service.Port }}
     name: cache
     targetPort: squid
-    {{ if eq .Values.Service.ExternalVisibility "NodePort" }}
-    {{ if .Values.Service.NodePort }}
+    {{- if eq .Values.Service.ExternalVisibility "NodePort" }}
+    {{- if .Values.Service.NodePort }}
     nodePort: {{ .Values.Service.NodePort }}
-    {{ end }}
-    {{ end }}
+    {{- end }}
+    {{- end }}
   - port: {{ .Values.Service.MonitoringPort }}
     name: monitoring
     targetPort: monitoring
     protocol: UDP
-    {{ if eq .Values.Service.ExternalVisibility "NodePort" }}
-    {{ if .Values.Service.NodePort }}
+    {{- if eq .Values.Service.ExternalVisibility "NodePort" }}
+    {{- if .Values.Service.NodePort }}
     nodePort: {{ .Values.Service.MonitoringNodePort }}
-    {{ end }}
-    {{ end }}
+    {{- end }}
+    {{- end }}


### PR DESCRIPTION
This does a formatting pass across the squid chart to properly align comments and will chomp extraneous newlines, so the output via `helm template` looks much cleaner.

E.g., before:
```# Source: osg-frontier-squid/templates/service.yaml
kind: Service
apiVersion: v1
metadata:
  name: osg-frontier-squid
  labels:
    app: osg-frontier-squid
    release: RELEASE-NAME
    instance: ""
spec:
  type: NodePort
  
  externalTrafficPolicy: Local
  
  selector:
    app: osg-frontier-squid
    release: RELEASE-NAME
    instance: ""
  ports:
  - port: 3128
    name: cache
    targetPort: squid
    
    
    
  - port: 3401
    name: monitoring
    targetPort: monitoring
    protocol: UDP
```

After:
```# Source: osg-frontier-squid/templates/service.yaml
kind: Service
apiVersion: v1
metadata:
  name: osg-frontier-squid
  labels:
    app: osg-frontier-squid
    release: RELEASE-NAME
    instance: ""
spec:
  type: NodePort
  externalTrafficPolicy: Local
  selector:
    app: osg-frontier-squid
    release: RELEASE-NAME
    instance: ""
  ports:
  - port: 3128
    name: cache
    targetPort: squid
  - port: 3401
    name: monitoring
    targetPort: monitoring
    protocol: UDP
```