### PR TITLE
osg-hosted-ce: merge stable, close port 80 if we don't need it for Let's Encrypt (incubator)

### DIFF
--- a/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "5.1.5"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.17.1
+version: 3.17.2

--- a/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "5.1.3"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.16.1
+version: 3.16.2

--- a/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "5.1.3"
+appVersion: "5.1.5"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.16.2
+version: 3.17.1

--- a/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "5.1.5"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 3.17.2
+version: 4.1.0

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/configmap.yaml
@@ -100,41 +100,6 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: osg-hosted-ce-{{ .Values.Instance }}-voms-mapfile
-  labels:
-    app: osg-hosted-ce
-    instance: {{ .Values.Instance }}
-    release: {{ .Release.Name }}
-data:
-  voms-mapfile: |+
-    {{- range $index, $map := .Values.VoRemoteUserMapping }}
-    {{- range $voms, $user := $map }}
-    {{ $voms | quote }} {{ $user }}
-    {{- end }}
-    {{- end }}
-{{ if .Values.DnRemoteUserMapping }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: osg-hosted-ce-{{ .Values.Instance }}-grid-mapfile
-  labels:
-    app: osg-hosted-ce
-    instance: {{ .Values.Instance }}
-    release: {{ .Release.Name }}
-data:
-  grid-mapfile: |+
-    {{- range $index, $map := .Values.DnRemoteUserMapping }}
-    {{- range $dn, $user := $map }}
-    {{ $dn | quote }} {{ $user }}
-    {{- end}}
-    {{- end }}
-{{ end }}
-{{ if .Values.SciTokenRemoteUserMapping }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
   name: osg-hosted-ce-{{ .Values.Instance }}-slate-scitokens
   labels:
     app: osg-hosted-ce
@@ -147,7 +112,6 @@ data:
     SCITOKENS /^{{ $url | replace "/" "\\/" | replace "." "\\." | replace "-" "\\-" }}{{ if not ( $url | contains "," ) }},{{ end }}/ {{ $user }}
     {{- end }}
     {{- end }}
-{{ end }}
 {{ if .Values.HTTPLogger.Enabled }}
 ---
 apiVersion: v1

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -234,9 +234,11 @@ spec:
         - name: htcondor-ce
           containerPort: 9619
           protocol: TCP
-        - name: http # needed to get a cert issued from Let's Encrypt
+        {{ if and (not .Values.HostCredentials.HostCertKeySecret) (not .Values.HostCredentials.HostCertSecret) }}
+        - name: http # needed to get a cert issued from Let's Encrypt (since the admin's not supplying a cert/key as a secret)
           containerPort: 80
           protocol: TCP
+        {{ end }}
         env:
         {{ if eq .Values.Networking.ServiceType "HostNetwork" }}
         - name: _CONDOR_NETWORK_HOSTNAME

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/deployment.yaml
@@ -39,19 +39,9 @@ spec:
       - name: osg-hosted-ce-{{ .Values.Instance }}-htcondor-ce-configuration
         configMap:
           name: osg-hosted-ce-{{ .Values.Instance }}-htcondor-ce-configuration
-      - name: osg-hosted-ce-{{ .Values.Instance }}-voms-mapfile
-        configMap:
-          name: osg-hosted-ce-{{ .Values.Instance }}-voms-mapfile
-      {{ if .Values.DnRemoteUserMapping }}
-      - name: osg-hosted-ce-{{ .Values.Instance }}-grid-mapfile
-        configMap:
-          name: osg-hosted-ce-{{ .Values.Instance }}-grid-mapfile
-      {{ end }}
-      {{ if .Values.SciTokenRemoteUserMapping }}
       - name: osg-hosted-ce-{{ .Values.Instance }}-slate-scitokens
         configMap:
           name: osg-hosted-ce-{{ .Values.Instance }}-slate-scitokens
-      {{ end }}
       - name: bosco-ssh-private-key-volume
         secret: 
           secretName: {{ .Values.RemoteCluster.PrivateKeySecret }}
@@ -216,14 +206,6 @@ spec:
           mountPath: /etc/osg/git.key
           subPath: git.key
         {{ end }}
-        {{ end }}
-        - name: osg-hosted-ce-{{ .Values.Instance }}-voms-mapfile
-          mountPath: /etc/grid-security/voms-mapfile
-          subPath: voms-mapfile
-        {{ if .Values.DnRemoteUserMapping }}
-        - name: osg-hosted-ce-{{ .Values.Instance }}-grid-mapfile
-          mountPath: /etc/grid-security/grid-mapfile
-          subPath: grid-mapfile
         {{ end }}
         {{ if .Values.SciTokenRemoteUserMapping }}
         - name: osg-hosted-ce-{{ .Values.Instance }}-slate-scitokens

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/service.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/service.yaml
@@ -17,8 +17,8 @@ spec:
     port: 9619
     targetPort: htcondor-ce
     protocol: TCP
-  {{ if and (not .Values.HostCertKeySecret) (not .Values.HostKeySecret) }}
-  - name: http
+  {{ if and (not .Values.HostCredentials.HostCertKeySecret) (not .Values.HostCredentials.HostCertSecret) }}
+  - name: http  # needed to get a cert issued from Let's Encrypt (since the admin's not supplying a cert/key as a secret)
     port: 80
     targetPort: http
     protocol: TCP

--- a/incubator/osg-hosted-ce/osg-hosted-ce/templates/service.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/templates/service.yaml
@@ -17,10 +17,12 @@ spec:
     port: 9619
     targetPort: htcondor-ce
     protocol: TCP
+  {{ if and (not .Values.HostCertKeySecret) (not .Values.HostKeySecret) }}
   - name: http
     port: 80
     targetPort: http
     protocol: TCP
+  {{ end }}
   {{ if .Values.HTTPLogger.Enabled }}
   - port: 8080
     targetPort: logs

--- a/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -229,7 +229,7 @@ HostCredentials:
 
 # Choose which tag to use for the specified containers
 ContainerTags:
-  HostedCE: release
+  HostedCE: 3.6-release
 
 Debug:
   # When 'ContinuOnError: true', ignore fatal errors on startup

--- a/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/incubator/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -128,46 +128,6 @@ SciTokenRemoteUserMapping:
 # OPTIONAL CONFIGURATION #
 ##########################
 
-# DN to remote user mapping
-# For example, you may add your personal certificate's subject DN so
-# that you can submit jobs to this CE
-#DnRemoteUserMapping:
-#  - "/DC=foo/DC=bar/OU=Organic Units/OU=Users/CN=YourUserName": osg01
-
-# VOMS FQAN to remote user mapping
-# To add custom VOMS FQAN mappings, add a new item to the list.
-# VOMS FQANs can include "*" wildcards.
-# VoRemoteUserMapping:
-  # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/OSG.yaml
-  # - "/osg/Role=NULL/Capability=NULL": osg01
-  # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/GLOW.yaml
-  # - "/GLOW/Role=htpc/Capability=NULL": osg02
-  # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/HCC.yaml
-  # - "/hcc/Role=NULL/Capability=NULL": osg03
-  # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/CMS.yaml
-  # - "/cms/*": osg04
-  # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/Fermilab.yaml
-  # - "/fermilab/*": osg05
-  # osg06 reserved for JLAB
-  # LIGO-Virgo collaboration
-  # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/LIGO.yaml
-  # - "/osg/ligo/Role=NULL/Capability=NULL": osg07
-  # - "/virgo/ligo/Role=NULL/Capability=NULL": osg07
-  # Brookhaven National Lab VOs
-  # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/sPHENIX.yaml
-  # - "/sdcc/Role=NULL/Capability=NULL": osg08
-  # - "/sphenix/Role=NULL/Capability=NULL": osg08
-  # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/ATLAS.yaml
-  # - "/atlas/*": osg09
-  # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/Gluex.yaml
-  # - "/Gluex/Role=NULL/Capability=NULL": osg10
-  # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/DUNE.yaml
-  # - "/dune/Role=pilot/Capability=NULL": osg11
-  # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/IceCube.yaml
-  # - "/icecube/Role=pilot/Capability=NULL": osg12
-  # https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/XENON.yaml
-  # - "/xenon.biggrid.nl/Role=NULL/Capability=NULL": osg13
-
 # Specify additional HTCondor-CE configuration
 # HTCondorCeConfig: |+
 #   ALL_DEBUG = D_ALWAYS:2 D_CAT


### PR DESCRIPTION
- Merge changes from stable/osg-hosted-ce again
- Modify the deployment and service templates such that we only open port 80 if the values don't specify a host cert or certkey