### PR TITLE
Add a way to provide arbitrary annotations to the Service of an osg-hosted-ce

### DIFF
--- a/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "5.1.5"
 description: OSG Hosted Compute Element
 name: osg-hosted-ce
-version: 4.2.0
+version: 4.3.0
 

--- a/stable/osg-hosted-ce/osg-hosted-ce/templates/service.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/templates/service.yaml
@@ -8,7 +8,10 @@ metadata:
     release: {{ .Release.Name }}
     instance: {{ .Values.Instance }}
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: {{ .Values.Networking.Hostname }} 
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.Networking.Hostname }}
+    {{- with .Values.ServiceAnnotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: LoadBalancer
   externalTrafficPolicy: "Local"

--- a/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
+++ b/stable/osg-hosted-ce/osg-hosted-ce/values.yaml
@@ -183,6 +183,14 @@ NodeSelection:
   # NodeLabels:
   #  kubernetes.io/hostname: example.host.org
 
+# Arbitrary annotations to add to the Service in case your Kubernetes cluster
+# requires them.  Use sparingly.  For example:
+#
+# ServiceAnnotations:
+#   metallb.universe.tf/address-pool: tiger-vlan5
+
+ServiceAnnotations: {}
+
 HostCredentials:
   # Name of the secret containing a host key and certificate in
   # "tls.key" and "tls.crt", respectively. If defined, values of


### PR DESCRIPTION
We're moving some of our hosts to a separate VLAN and need to be able to specify an annotation to make sure MetalLB allocates an IP on the same VLAN that the pod is running on.